### PR TITLE
Augment grammar with simple math, bool ops and predicate decl + Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ To factor a grammar into multiple sub-grammars: <https://github.com/eclipse-lang
 * [Tonto](https://matheuslenke.github.io/tonto-docs/)'s syntax choices are helpful -- they seemed to have put quite a bit of effort into finding intuitive names, and their language was "designed to allow transformation to a number of languages including UML (more specifically OntoUML), OWL (for gUFO-based ontologies), Alloy" etc
   * Think about whether to use `SPECIALIZES` instead of `SUBSET_OF`, and whether to use `KIND` or `TYPE` instead of `SIG`
 
-### Visualizations
+### Visualizations and Explainability
 
 Useful links:
 
@@ -83,7 +83,11 @@ Useful links:
 * [Integrating Langium with a UI Editor like React-flow](https://github.com/eclipse-langium/langium/discussions/1373)
 * [SvelteFlow](https://svelteflow.dev/)
 
-Visual diagramming languages
+#### Explainability
+
+* [Whyline: "a debugging tool that allows programmers to ask "Why did" and "Why didn't" questions about their program's output".](https://www.cs.cmu.edu/~NatProg/whyline.html) Useful ideas here, both UX and implementation-wise, for both the 'chatobt' and IDE.
+
+#### Visual diagramming languages
 
 * <https://www.thestrangeloop.com/2022/diagrammar-simply-make-interactive-diagrams.html>
 * An *un*related diagrammar, this time a dataflow PL: <https://github.com/billbudge/Diagrammar>

--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ To factor a grammar into multiple sub-grammars: <https://github.com/eclipse-lang
 
 ## Things to think about
 
+### IDE protocol / synchronizing state between, e.g., a textual editor and a diagrammatic one
+
+* <https://matklad.github.io/2023/10/12/lsp-could-have-been-better.html>
+  * "what I think is the biggest architectural issue with LSP [...] LSP is an RPC protocol — it is formed by “edge triggered” requests that make something happen on the other side. But this is not how most of IDE features work. What actually is needed is “level triggered” state synchronization. The client and the server need to agree what something is, deciding the course of action is secondary. It is “to be or not to be” rather than “what is to be done”."
+* <https://htmlpreview.github.io/?https://github.com/dart-lang/sdk/blob/8e6a02d899ef62ef5b8405518b36340e609198e2/pkg/analysis_server/doc/api.html>
+* <https://www.codemag.com/Article/1811091/Building-a-.NET-IDE-with-JetBrains-Rider>
+
 ### Concrete syntax
 
 * [Tonto](https://matheuslenke.github.io/tonto-docs/)'s syntax choices are helpful -- they seemed to have put quite a bit of effort into finding intuitive names, and their language was "designed to allow transformation to a number of languages including UML (more specifically OntoUML), OWL (for gUFO-based ontologies), Alloy" etc

--- a/README.md
+++ b/README.md
@@ -68,6 +68,31 @@ To factor a grammar into multiple sub-grammars: <https://github.com/eclipse-lang
 
 ## Things to think about
 
+### Concrete syntax
+
+* [Tonto](https://matheuslenke.github.io/tonto-docs/)'s syntax choices are helpful -- they seemed to have put quite a bit of effort into finding intuitive names, and their language was "designed to allow transformation to a number of languages including UML (more specifically OntoUML), OWL (for gUFO-based ontologies), Alloy" etc
+  * Think about whether to use `SPECIALIZES` instead of `SUBSET_OF`, and whether to use `KIND` or `TYPE` instead of `SIG`
+
+### Visualizations
+
+Useful links:
+
+* [Eclipse Graphical Language Server Platform for next-generation diagram editors (GLSP)](https://eclipse.dev/glsp/)
+
+* [Tonto - A Textual Syntax for OntoUML](https://matheuslenke.github.io/tonto-docs/) and their [Visual Paradigm plugin](https://github.com/OntoUML/ontouml-vp-plugin) --- example diagrams are available in the readme for the latter
+* [Integrating Langium with a UI Editor like React-flow](https://github.com/eclipse-langium/langium/discussions/1373)
+* [SvelteFlow](https://svelteflow.dev/)
+
+Visual diagramming languages
+
+* <https://www.thestrangeloop.com/2022/diagrammar-simply-make-interactive-diagrams.html>
+* An *un*related diagrammar, this time a dataflow PL: <https://github.com/billbudge/Diagrammar>
+* See [Enso IDE](https://github.com/enso-org/enso/tree/develop/app/gui2) for a nice example of a visual programming language / editor
+* Visual Haskell: <https://github.com/rgleichman/glance> and <https://github.com/Only1Loatheb/glance/> and <https://www.youtube.com/watch?v=cb25Ts4rLXA>
+* [Flyde](https://github.com/flydelabs/flyde) "is an open-source visual programming language built to integrate with your existing codebase. It allows you to create and run visual programs and is designed to complement and enhance traditional textual coding, not to replace it."
+* [Flowblocks](https://github.com/jyjblrd/flowblocks) "FlowBlocks is a visual interface for programming the Raspberry Pi Pico [...] With FlowBlocks, users can build programs by dragging and dropping blocks from a comprehensive standard library of inputs, operators, and outputs, and connecting them into flowcharts, which describe the flow of data throughout a program. In addition, experienced users also have the option of creating custom blocks—written with a templating dialect of MicroPython"
+* [To Dissect a Mockingbird: A Graphical Notation for the Lambda Calculus with Animated Reduction](<https://dkeenan.com/Lambda/>)
+
 ### How to get interop --- in particular, how to enabling interfacing with L4 from other languages
 
 1. Have one L4 runtime; put it behind a REST API or use some sort of RPC (and maybe also offer more ergonomic wrappers around http or rpc clients, e.g. in the same way that [the OpenAPI python lib](https://github.com/openai/openai-python) basically wraps their REST API; c.f. also things like vscode rpc)

--- a/lam4-parser/examples/open_sums.l4
+++ b/lam4-parser/examples/open_sums.l4
@@ -1,0 +1,37 @@
+GENERAL_METADATA_FOR_TYPES {
+  description: "An example that demonstrates how to get open sums with SUBSET_OF"
+}
+
+/* -----------------------
+    Entities
+-------------------------*/
+SIG Entity {
+  name: String
+}
+
+SIG Institution SUBSET_OF Entity {}
+
+SIG Government SUBSET_OF Institution {}
+
+SIG Business SUBSET_OF Institution {
+  date_incorporated: Date
+  market_share: Fraction
+}
+
+SIG NonProfitInstitution SUBSET_OF Institution {}
+
+SIG NonInstitutionalPerson SUBSET_OF Entity {}
+
+
+SIG Loan {
+  /-
+  description_for_semantic_parser: "Who the lender is"
+  someNumericMetadataForIllustration: 12.30
+  -/
+  lender IS ONE Entity
+  // the property above has a 'block metadata' annotation 
+  // just to show how that syntax is possible
+
+  // the properties below just have a single line metadata annotation (this will become the 'description')
+  borrower IS ONE Entity -- Who the borrower is.
+}

--- a/lam4-parser/package.json
+++ b/lam4-parser/package.json
@@ -51,7 +51,7 @@
         "langium-cli": "~3.0.0",
         "typescript": "~5.1.6",
         "vite": "~4.4.11",
-        "vitest": "~1.0.0"
+        "vitest": "~1.4.0"
     },
     "displayName": "lam4",
     "engines": {

--- a/lam4-parser/src/language/lam4.langium
+++ b/lam4-parser/src/language/lam4.langium
@@ -51,14 +51,31 @@ See also
     * https://json-schema.org/understanding-json-schema/reference
     * https://swagger.io/docs/specification/data-models/data-types/
 
-Note:
+==========================================
+    Langium Notes
+==========================================
+
     * Keywords can't include whitespace: https://github.com/eclipse-langium/langium/discussions/601
+    * Avoid using newline as a delimiter: https://github.com/eclipse-langium/langium/discussions/1510
+        > "I would generally recommend against employing newline-delimited languages, as they don't behave very well when it comes to error recovery behavior in Langium. Unless you're reimplementing an existing language in Langium, you're almost always better suited using a different delimiter like `;`. Generic parsers are generally pretty bad at handling unexpected input in whitespace-aware languages. It also makes maintenance on the grammar pretty difficult, as you always need to keep track where a newline (or multiple newlines) is required/optional/not allowed."
+        
 */
 
-entry Model:
+entry Program:
+    (Model)?
+    (Rules)?
+;
+
+Model:
     ('GENERAL_METADATA_FOR_TYPES' gen_metadata=MetadataBlock)*
     (types+=CustomType*)*
 ;
+
+Rules:
+    ('GENERAL_METADATA_FOR_RULES' gen_metadata=MetadataBlock)*
+    (rules+=Rule)*
+;
+
 
 /* ========================================
        Metadata
@@ -86,6 +103,20 @@ MetadataForRelation:
         properties+=MetadataKVPair+
     '-/'
 ;
+
+
+
+
+/* ========================================
+       Rules
+======================================== */
+
+// Rule:
+
+/* ========================================
+       Sigs
+======================================== */
+
 
 SigDecl:
     'DECLARE'? 'SIG' name=ID 
@@ -129,9 +160,9 @@ TypeDef:
 ;
 
 
-// /* ========================================
-//         BUILT INs and PRIMITIVEs
-// ======================================== */
+/* ========================================
+         BUILT IN and PRIMITIVE types
+ ======================================== */
 
 // TODO: Go through these more carefully; remove the ones we don't need or won't be able to support in the very short term
 

--- a/lam4-parser/src/language/lam4.langium
+++ b/lam4-parser/src/language/lam4.langium
@@ -14,6 +14,20 @@ TO DOs
 1. Think about whether to refactor this into 2 sub-grammars
 https://langium.org/docs/recipes/multiple-languages/
 
+============================================
+Is it important to support mixfix operators?
+============================================
+
+I was initially worried about this.
+But after thinking about it more and looking at a range of examples 
+(Meng's and Joe's formalizations, various spreadsheet examples, etc), 
+I don't feel as worried -- a lot of the uses of mixfix in the LE-targeted-formalizations
+can be rephrased, and in any case, it doesn't seem as necessary in a more functional style.
+It feels enough to support Haskell-like infix.
+And it's also not clear that long mixfix'd expressions are that understandable to non-programmers anyway.
+In particular, I'm not sure if a non-programmer is going to understand
+what it really means without understanding enough of the underlying semantics.
+
 ====================
 What built-in types?
 ====================
@@ -58,21 +72,21 @@ See also
     * Keywords can't include whitespace: https://github.com/eclipse-langium/langium/discussions/601
     * Avoid using newline as a delimiter: https://github.com/eclipse-langium/langium/discussions/1510
         > "I would generally recommend against employing newline-delimited languages, as they don't behave very well when it comes to error recovery behavior in Langium. Unless you're reimplementing an existing language in Langium, you're almost always better suited using a different delimiter like `;`. Generic parsers are generally pretty bad at handling unexpected input in whitespace-aware languages. It also makes maintenance on the grammar pretty difficult, as you always need to keep track where a newline (or multiple newlines) is required/optional/not allowed."
-        
+
 */
 
 entry Program:
-    (Model)?
+    (Types)?
     (Rules)?
 ;
 
-Model:
-    ('GENERAL_METADATA_FOR_TYPES' gen_metadata=MetadataBlock)*
+Types:
+    ("GENERAL_METADATA_FOR_TYPES" gen_metadata=MetadataBlock)*
     (types+=CustomType*)*
 ;
 
 Rules:
-    ('GENERAL_METADATA_FOR_RULES' gen_metadata=MetadataBlock)*
+    ("GENERAL_METADATA_FOR_RULES" gen_metadata=MetadataBlock)*
     (rules+=Rule)*
 ;
 
@@ -105,13 +119,87 @@ MetadataForRelation:
 ;
 
 
-
-
 /* ========================================
        Rules
 ======================================== */
 
-// Rule:
+// ------- Params -------
+ParamBlock:
+    'GIVEN''{'
+        params+=ParamTypePair+
+    '}'
+;
+
+Param:
+    {infer Param} ID
+;
+
+ParamTypePair:
+    name=Param (':' | 'IS_A') paramType=TypeDef
+;
+
+// ------- PredicateDecl, FunDecl -------
+
+/* TODO:
+    FunDecl
+    FunApp */
+
+Rule:
+    PredicateDecl
+    // | FunDecl ??
+;
+
+PredicateDecl:
+    ParamBlock?
+    'DECIDE' head=PredicateOrFuncID
+    'IF' body=Expr 
+    // IMPT: The 'IF' here is probably going to be a 'IFF' or 'just in case', rather than a mere 'if'
+;
+
+PredicateOrFuncID:
+    {infer PredicateOrFuncID} value=(ID | BACK_TICKED_ID)
+;
+
+
+// ------- Expr -------
+
+Expr:
+    OrExpr
+;
+
+OrExpr infers Expr:
+    AndExpr ({infer BinBoolOp.left=current} op='OR' right=AndExpr)*
+;
+
+AndExpr infers Expr:
+    NumComparisonExpr ({infer BinBoolOp.left=current} op='AND' right=NumComparisonExpr)*
+;
+
+
+NumComparisonExpr infers Expr:
+    Add ({infer ComparisonOp.left=current} op=('<' | '<=' | '>' | '>=' | 'EQUALS' | 'NOT_EQUAL' | '==' | '!=') right=Add)*
+;
+
+
+Add infers Expr:
+    Mult ({infer NumOp.left=current} op=('+' | '-') right=Mult)*
+;
+
+Mult infers Expr:
+    PrimitiveExpr ({infer NumOp.left=current} op=('*' | '/') right=PrimitiveExpr)*
+;
+
+PrimitiveExpr infers Expr:
+    '(' Expr ')' | UnaryExpr | NumberLiteral | StringLiteral | BooleanLiteral
+;
+
+UnaryExpr:
+    op=('-' | 'NOT') value=Expr
+;
+
+
+type NamedElement = Param | PredicateDecl | SigDecl | Relation;
+
 
 /* ========================================
        Sigs
@@ -125,14 +213,6 @@ SigDecl:
         relations+=Relation*
     '}'
 ;
-
-// UnionType:
-//     'UNION' name=ID '=' types+=[ValueType:ID] ( '|' types+=[ValueType:ID] )+
-// ;
-
-// Alias:
-//     'ALIAS' name=ID '=' type=Type
-// ;
 
 CustomType:
     SigDecl 
@@ -190,31 +270,6 @@ Builtin returns string:
 //     'Money(USDCents)' | 'Money(SGDCents)' | 'Money(Other)'
 // ;
 
-// If you were trying to model OpenAPI, you would use the following too:
-// BuiltinIntegerFormats returns string:
-//     'int32' | 'int64'
-// ;
-// BuiltinFloatFormats returns string:
-//     'float'
-// ;
-// PrimitiveString:
-//     type='string' '(' format=(ID|BuiltinStringFormats) ')'
-// ;
-
-// Primitive:
-//     PrimitiveString | PrimitiveFloats | PrimitiveIntegers;
-
-// PrimitiveFloats:
-//     'number' '(' format=(ID|BuiltinFloatFormats) ')' 
-//         (lowerBound=('('|'[') lower=INT? ',' upper=INT? upperBound=(')'|']'))?
-//         ('mul' multipleOf=UNSIGNED_NUMBER)?
-// ;
-
-// PrimitiveIntegers:
-//     'integer' '(' format=(ID|BuiltinIntegerFormats) ')' 
-//         (lowerBound=('('|'[') lower=INT? ',' upper=INT? upperBound=(')'|']'))?
-//         ('mul' multipleOf=UNSIGNED_NUMBER)?
-// ;
 
 /* ========================================
         LITERALS
@@ -246,6 +301,9 @@ terminal INT returns number: /[0-9]+/;
 terminal SIGNED_NUMBER returns number: /-\d+((\.\d+)?([eE][\-+]?\d+)?)?/;
 terminal UNSIGNED_NUMBER returns number: /\d+((\.\d+)?([eE][\-+]?\d+)?)?/;
 terminal STRING: /"(\\.|[^"\\])*"|'(\\.|[^'\\])*'/;
+terminal BACK_TICKED_ID:
+    '`' -> '`'
+;
 
 // TODO: Figure out how to just drop the "--.."
 // matches --


### PR DESCRIPTION
Augmented Lam4 langium grammar with:
* simple math, bool ops 
* predicate decl
 
Docs (README + comments in Langium grammar file):
* Add misc thoughts on visualization and explanation
* Add thoughts on how important it is to support mixfix operators
* Add links re IDE protocol / synchronizing state between, e.g., a textual editor and a diagrammatic one

Deps:
* upgrade vitest