### PR TITLE
Add a backend parser that parses in the ('minimal ast' version of the) concrete syntax json from Langium parser (closes #44)

### DIFF
--- a/lam4-backend/app/Main.hs
+++ b/lam4-backend/app/Main.hs
@@ -1,7 +1,47 @@
 module Main where
 
--- import qualified MyLib (someFunc)
+import           Base
+import qualified Base.ByteString     as BL hiding (null)
+import           Lam4.Expr.Parser    (parseProgramByteStr)
+import           Lam4.Parser.Monad   (evalParserFromScratch)
+import           Options.Applicative as Options
+
+data Options =
+  MkOptions
+    { files   :: [FilePath]
+    }
+
+optionsDescription :: Options.Parser Options
+optionsDescription =
+  MkOptions
+  <$> many (strArgument (metavar "CONCRETE SYNTAX JSONs..."))
+
+optionsConfig :: Options.ParserInfo Options
+optionsConfig =
+  info (optionsDescription <**> helper)
+    (  fullDesc
+    <> header "Lam4 Backend"
+    )
+
 
 main :: IO ()
 main = do
-  putStrLn "Hello, Haskell!"
+  options <- Options.execParser optionsConfig
+  if null options.files
+    then do
+      hPutStrLn stderr "Lam4 Backend: no input files given; use --help for help"
+    else do parseProgramFiles options.files
+
+parseProgramFile :: FilePath -> IO ()
+parseProgramFile file = do
+  bsFile <- BL.readFile file
+  case evalParserFromScratch . parseProgramByteStr $ bsFile of
+    Left err  -> pPrint err
+    Right cst -> pPrint cst
+
+parseProgramFiles :: [FilePath] -> IO ()
+parseProgramFiles inputFiles = do
+  forM_ inputFiles (\f -> do
+    pPrint f
+    parseProgramFile f)
+    

--- a/lam4-backend/app/Main.hs
+++ b/lam4-backend/app/Main.hs
@@ -20,10 +20,10 @@ optionsConfig :: Options.ParserInfo Options
 optionsConfig =
   info (optionsDescription <**> helper)
     (  fullDesc
-    <> header "Lam4 Backend"
+    <> header "Lam4 Backend. This is an *internal*, *unstable* cli that can see breaking changes any time --- use at your own risk!"
     )
 
-
+-- | This will be wired up to an evaluator instead of just the parser in the near future
 main :: IO ()
 main = do
   options <- Options.execParser optionsConfig

--- a/lam4-backend/lam4-backend.cabal
+++ b/lam4-backend/lam4-backend.cabal
@@ -79,7 +79,8 @@ library
         aeson-combinators,
         jsonpath,
         bytestring,
-        either
+        either,
+        pretty-show
 
 
 executable lam4-backend

--- a/lam4-backend/lam4-backend.cabal
+++ b/lam4-backend/lam4-backend.cabal
@@ -67,6 +67,7 @@ library
     build-depends:
         base,
         containers,
+        foldable1-classes-compat,
         lens,
         optics,
         mtl,

--- a/lam4-backend/lam4-backend.cabal
+++ b/lam4-backend/lam4-backend.cabal
@@ -70,6 +70,7 @@ library
         lens,
         optics,
         mtl,
+        transformers-base,
         prettyprinter,
         text,
         aeson,

--- a/lam4-backend/lam4-backend.cabal
+++ b/lam4-backend/lam4-backend.cabal
@@ -52,12 +52,14 @@ library
         Base
         Base.IntMap
         Base.Map
+        Base.Plated
         Base.Text
         Base.Aeson
         Base.ByteString
         -- Base.MyAesonValueParser
         Lam4.Expr.Name
         Lam4.Expr.ConcreteSyntax
+        Lam4.Expr.Parser
         Lam4.Parser.Type
         Lam4.Parser.Monad
 
@@ -65,6 +67,7 @@ library
     build-depends:
         base,
         containers,
+        lens,
         optics,
         mtl,
         prettyprinter,
@@ -72,6 +75,7 @@ library
         aeson,
         aeson-value-parser,
         aeson-optics,
+        aeson-combinators,
         jsonpath,
         bytestring,
         either
@@ -89,7 +93,7 @@ executable lam4-backend
 
     hs-source-dirs:   app
     build-depends:
-        base ^>=4.18.2.0,
+        base,
         optparse-applicative,
         bytestring,
         lam4-backend

--- a/lam4-backend/lam4-backend.cabal
+++ b/lam4-backend/lam4-backend.cabal
@@ -73,7 +73,6 @@ library
         prettyprinter,
         text,
         aeson,
-        -- aeson-value-parser,
         aeson-optics,
         aeson-combinators,
         jsonpath,

--- a/lam4-backend/lam4-backend.cabal
+++ b/lam4-backend/lam4-backend.cabal
@@ -55,8 +55,8 @@ library
         Base.Plated
         Base.Text
         Base.Aeson
+        Base.AesonCombinators
         Base.ByteString
-        -- Base.MyAesonValueParser
         Lam4.Expr.Name
         Lam4.Expr.ConcreteSyntax
         Lam4.Expr.Parser
@@ -73,7 +73,7 @@ library
         prettyprinter,
         text,
         aeson,
-        aeson-value-parser,
+        -- aeson-value-parser,
         aeson-optics,
         aeson-combinators,
         jsonpath,

--- a/lam4-backend/lam4-backend.cabal
+++ b/lam4-backend/lam4-backend.cabal
@@ -54,10 +54,13 @@ library
         Base.Map
         Base.Text
         Base.Aeson
+        Base.ByteString
         -- Base.MyAesonValueParser
         Lam4.Expr.Name
         Lam4.Expr.ConcreteSyntax
         Lam4.Parser.Type
+        Lam4.Parser.Monad
+
 
     build-depends:
         base,
@@ -68,8 +71,10 @@ library
         text,
         aeson,
         aeson-value-parser,
+        aeson-optics,
         jsonpath,
-        bytestring
+        bytestring,
+        either
 
 
 executable lam4-backend

--- a/lam4-backend/src/Base.hs
+++ b/lam4-backend/src/Base.hs
@@ -10,7 +10,7 @@ import Control.Monad.State as X
 import Data.Coerce as X
 -- import Data.IORef as X
 import Data.Kind as X
-import Data.List as X
+import Data.List as X hiding (uncons)
 import Data.Map.Strict as X (Map, (!))
 import Data.Maybe as X
 import Data.Set as X (Set)
@@ -20,5 +20,7 @@ import Data.Void as X
 import GHC.Generics as X (Generic)
 import Optics.Setter as X
 import Optics.State as X
+import Optics.At as X
+import Optics as X
 import Prettyprinter as X (Doc, Pretty(..), (<+>))
 import System.IO as X

--- a/lam4-backend/src/Base.hs
+++ b/lam4-backend/src/Base.hs
@@ -20,6 +20,7 @@ import Data.Void as X
 import GHC.Generics as X (Generic)
 import Optics.Setter as X
 import Optics.State as X
+import Optics.State.Operators as X ((.=), (%=), (<%=))
 import Optics.At as X
 import Optics as X
 import Prettyprinter as X (Doc, Pretty(..), (<+>))

--- a/lam4-backend/src/Base.hs
+++ b/lam4-backend/src/Base.hs
@@ -24,3 +24,4 @@ import           Optics.Operators.Unsafe as X
 import           Optics.State.Operators  as X ((%=), (.=), (<%=))
 import           Prettyprinter           as X (Doc, Pretty (..), (<+>))
 import           System.IO               as X
+import           Text.Show.Pretty        as X (pPrint, ppShow)

--- a/lam4-backend/src/Base.hs
+++ b/lam4-backend/src/Base.hs
@@ -1,27 +1,25 @@
--- | Defines a project-specific "prelude". Adapted from Simala, though I think this is a pretty common practice
+-- | Defines a project-specific "prelude". Adapted from Simala, though I think this is a common practice
 --
 module Base (module X) where
 
-import Control.Monad as X
-import Control.Monad.Except as X
-import Control.Monad.Identity as X
-import Control.Monad.Reader as X
-import Control.Monad.State as X
-import Data.Coerce as X
+import           Control.Monad          as X
+import           Control.Monad.Except   as X
+import           Control.Monad.Identity as X
+import           Control.Monad.Reader   as X
+import           Control.Monad.State    as X
+import           Data.Coerce            as X
 -- import Data.IORef as X
-import Data.Kind as X
-import Data.List as X hiding (uncons)
-import Data.Map.Strict as X (Map, (!))
-import Data.Maybe as X
-import Data.Set as X (Set)
-import Data.String as X
-import Data.Text as X (Text)
-import Data.Void as X
-import GHC.Generics as X (Generic)
-import Optics.Setter as X
-import Optics.State as X
-import Optics.State.Operators as X ((.=), (%=), (<%=))
-import Optics.At as X
-import Optics as X
-import Prettyprinter as X (Doc, Pretty(..), (<+>))
-import System.IO as X
+import           Data.Kind              as X
+import           Data.List              as X hiding (uncons)
+import           Data.List.NonEmpty     as X (NonEmpty (..))
+import           Data.Map.Strict        as X (Map, (!))
+import           Data.Maybe             as X
+import           Data.Set               as X (Set)
+import           Data.String            as X
+import           Data.Text              as X (Text)
+import           Data.Void              as X
+import           GHC.Generics           as X (Generic)
+import           Optics                 as X
+import           Optics.State.Operators as X ((%=), (.=), (<%=))
+import           Prettyprinter          as X (Doc, Pretty (..), (<+>))
+import           System.IO              as X

--- a/lam4-backend/src/Base.hs
+++ b/lam4-backend/src/Base.hs
@@ -2,24 +2,25 @@
 --
 module Base (module X) where
 
-import           Control.Monad          as X
-import           Control.Monad.Except   as X
-import           Control.Monad.Identity as X
-import           Control.Monad.Reader   as X
-import           Control.Monad.State    as X
-import           Data.Coerce            as X
+import           Control.Monad           as X
+import           Control.Monad.Except    as X
+import           Control.Monad.Identity  as X
+import           Control.Monad.Reader    as X
+import           Control.Monad.State     as X
+import           Data.Coerce             as X
 -- import Data.IORef as X
-import           Data.Kind              as X
-import           Data.List              as X hiding (uncons)
-import           Data.List.NonEmpty     as X (NonEmpty (..))
-import           Data.Map.Strict        as X (Map, (!))
-import           Data.Maybe             as X
-import           Data.Set               as X (Set)
-import           Data.String            as X
-import           Data.Text              as X (Text)
-import           Data.Void              as X
-import           GHC.Generics           as X (Generic)
-import           Optics                 as X
-import           Optics.State.Operators as X ((%=), (.=), (<%=))
-import           Prettyprinter          as X (Doc, Pretty (..), (<+>))
-import           System.IO              as X
+import           Data.Kind               as X
+import           Data.List               as X hiding (uncons)
+import           Data.List.NonEmpty      as X (NonEmpty (..))
+import           Data.Map.Strict         as X (Map, (!))
+import           Data.Maybe              as X
+import           Data.Set                as X (Set)
+import           Data.String             as X
+import           Data.Text               as X (Text)
+import           Data.Void               as X
+import           GHC.Generics            as X (Generic)
+import           Optics                  as X
+import           Optics.Operators.Unsafe as X
+import           Optics.State.Operators  as X ((%=), (.=), (<%=))
+import           Prettyprinter           as X (Doc, Pretty (..), (<+>))
+import           System.IO               as X

--- a/lam4-backend/src/Base/Aeson.hs
+++ b/lam4-backend/src/Base/Aeson.hs
@@ -1,7 +1,18 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module Base.Aeson (module X) where
 
-import Data.Aeson as X
-import Data.Aeson.Types as X
-import Data.Aeson.KeyMap as X
-import Data.Aeson.Key as X
-import Data.Aeson.Optics as X
+import           Base.Plated       as X (Plated, plate, cosmos)
+import           Data.Aeson        as X
+import           Data.Aeson.Key    as X
+import           Data.Aeson.KeyMap as X
+import           Data.Aeson.Optics as X
+import           Data.Aeson.Types  as X
+
+
+instance Plated Value where
+  plate f (Object o) = Object <$> Prelude.traverse f o
+  plate f (Array a)  = Array <$> Prelude.traverse f a
+  plate _ xs         = pure xs
+  {-# INLINE plate #-}
+

--- a/lam4-backend/src/Base/Aeson.hs
+++ b/lam4-backend/src/Base/Aeson.hs
@@ -1,6 +1,6 @@
 module Base.Aeson (module X) where
 
--- import Data.Aeson as X
+import Data.Aeson as X
 import Data.Aeson.Types as X
 import Data.Aeson.KeyMap as X
 import Data.Aeson.Key as X

--- a/lam4-backend/src/Base/Aeson.hs
+++ b/lam4-backend/src/Base/Aeson.hs
@@ -1,10 +1,7 @@
-module Base.Aeson (module X, fromJSONValue) where
+module Base.Aeson (module X) where
 
-import Data.Aeson as X
+-- import Data.Aeson as X
 import Data.Aeson.Types as X
 import Data.Aeson.KeyMap as X
 import Data.Aeson.Key as X
 import Data.Aeson.Optics as X
-
-fromJSONValue :: FromJSON a => Value -> Maybe a
-fromJSONValue = parseMaybe parseJSON

--- a/lam4-backend/src/Base/Aeson.hs
+++ b/lam4-backend/src/Base/Aeson.hs
@@ -2,6 +2,9 @@ module Base.Aeson (module X, fromJSONValue) where
 
 import Data.Aeson as X
 import Data.Aeson.Types as X
+import Data.Aeson.KeyMap as X
+import Data.Aeson.Key as X
+import Data.Aeson.Optics as X
 
 fromJSONValue :: FromJSON a => Value -> Maybe a
 fromJSONValue = parseMaybe parseJSON

--- a/lam4-backend/src/Base/AesonCombinators.hs
+++ b/lam4-backend/src/Base/AesonCombinators.hs
@@ -1,0 +1,3 @@
+module Base.AesonCombinators (module X) where
+
+import Data.Aeson.Combinators.Decode as X

--- a/lam4-backend/src/Base/IntMap.hs
+++ b/lam4-backend/src/Base/IntMap.hs
@@ -1,3 +1,3 @@
 module Base.IntMap (module X) where
 
-import Data.IntMap as X
+import Data.IntMap.Strict as X

--- a/lam4-backend/src/Base/Plated.hs
+++ b/lam4-backend/src/Base/Plated.hs
@@ -1,4 +1,4 @@
-module Base.Plated (cosmos) where
+module Base.Plated (cosmos, Plated, plate) where
 
 import           Base
 import           Control.Lens.Plated (Plated, plate)

--- a/lam4-backend/src/Base/Plated.hs
+++ b/lam4-backend/src/Base/Plated.hs
@@ -1,0 +1,7 @@
+module Base.Plated (cosmos) where
+
+import           Base
+import           Control.Lens.Plated (Plated, plate)
+
+cosmos :: Plated a => Fold a a
+cosmos = cosmosOf (traversalVL plate)

--- a/lam4-backend/src/Lam4/Expr/ConcreteSyntax.hs
+++ b/lam4-backend/src/Lam4/Expr/ConcreteSyntax.hs
@@ -16,10 +16,18 @@ data Relatum
 data BuiltinTypeForRelation = BuiltinTypeString | BuiltinTypeInteger | BuiltinTypeBoolean
   deriving stock (Eq, Show, Ord, Generic)
 
+{- | References to where in the original source this corresponds to; e.g., §10.
+      In the future, the structure will be more complicated --- want to be able to support things like `§10(1)(a)`
+-}
+newtype OriginalRuleRef
+  = MkOriginalRuleRef Integer
+  deriving newtype (Eq, Ord)
+  deriving stock (Show)
 
--- newtype Program = MkProgram [Expr]
---   deriving stock (Show)
---   deriving newtype (Eq, Ord)
+data Decl =
+    NonRec Name Expr
+  | Rec    Name Expr
+  deriving stock Show
 
 -- TODO: think more about Sigs!
 data Expr
@@ -31,27 +39,13 @@ data Expr
   | FunApp     Expr [Expr]
   | PredApp    Expr [Expr]
   | Join       Expr Expr
-  | Fun        [Name] Expr          -- Function
-  | Predicate  [Name] Expr          -- Differs from a function when doing symbolic evaluation
+  | Fun        [Name] Expr (Maybe OriginalRuleRef) -- Function
+  | Predicate  [Name] Expr (Maybe OriginalRuleRef) -- Differs from a function when doing symbolic evaluation. Exact way in which they should differ is WIP.
   | Let        Name Expr Expr
   | Letrec     Name Expr Expr
-  -- | SeqOfExpr  SeqExpr
-  | Sig        [Name] [Expr]        -- Sig parents relations
-  | Relation   Relatum (Maybe Text) -- Relation relatum description
+  | Sig        [Name] [Expr]                       -- Sig parents relations
+  | Relation   Relatum (Maybe Text)                -- Relation relatum description
   deriving stock (Eq, Show, Ord)
-
--- newtype SeqExpr = MkSeqExpr [Expr]
---   deriving stock (Show, Generic, Eq, Ord)
---   deriving (Semigroup, Monoid) via [Expr]
-
--- seqExpToExprs :: SeqExpr -> [Expr]
--- seqExpToExprs = coerce
-
--- exprsToSeqExp :: [Expr] -> SeqExpr
--- exprsToSeqExp = coerce
-
--- consSeqExpr :: Expr -> SeqExpr -> SeqExpr
--- consSeqExpr expr (MkSeqExpr exprs) = exprsToSeqExp $ expr : exprs
 
 -- TODO: tweak the grammar to distinguish between integers and non-integers
 data Literal

--- a/lam4-backend/src/Lam4/Expr/ConcreteSyntax.hs
+++ b/lam4-backend/src/Lam4/Expr/ConcreteSyntax.hs
@@ -35,9 +35,23 @@ data Expr
   | Predicate  [Name] Expr          -- Differs from a function when doing symbolic evaluation
   | Let        Name Expr Expr
   | Letrec     Name Expr Expr
+  | SeqOfExpr  SeqExpr
   | Sig        [Name] [Expr]        -- Sig parents relations
   | Relation   Relatum (Maybe Text) -- Relation relatum description
   deriving stock (Eq, Show, Ord)
+
+newtype SeqExpr = MkSeqExpr [Expr]
+  deriving stock (Show, Generic, Eq, Ord)
+  deriving (Semigroup, Monoid) via [Expr]
+
+seqExpToExprs :: SeqExpr -> [Expr]
+seqExpToExprs = coerce
+
+exprsToSeqExp :: [Expr] -> SeqExpr
+exprsToSeqExp = coerce
+
+consSeqExpr :: Expr -> SeqExpr -> SeqExpr
+consSeqExpr expr (MkSeqExpr exprs) = exprsToSeqExp $ expr : exprs
 
 -- TODO: tweak the grammar to distinguish between integers and non-integers
 data Literal

--- a/lam4-backend/src/Lam4/Expr/ConcreteSyntax.hs
+++ b/lam4-backend/src/Lam4/Expr/ConcreteSyntax.hs
@@ -35,23 +35,23 @@ data Expr
   | Predicate  [Name] Expr          -- Differs from a function when doing symbolic evaluation
   | Let        Name Expr Expr
   | Letrec     Name Expr Expr
-  | SeqOfExpr  SeqExpr
+  -- | SeqOfExpr  SeqExpr
   | Sig        [Name] [Expr]        -- Sig parents relations
   | Relation   Relatum (Maybe Text) -- Relation relatum description
   deriving stock (Eq, Show, Ord)
 
-newtype SeqExpr = MkSeqExpr [Expr]
-  deriving stock (Show, Generic, Eq, Ord)
-  deriving (Semigroup, Monoid) via [Expr]
+-- newtype SeqExpr = MkSeqExpr [Expr]
+--   deriving stock (Show, Generic, Eq, Ord)
+--   deriving (Semigroup, Monoid) via [Expr]
 
-seqExpToExprs :: SeqExpr -> [Expr]
-seqExpToExprs = coerce
+-- seqExpToExprs :: SeqExpr -> [Expr]
+-- seqExpToExprs = coerce
 
-exprsToSeqExp :: [Expr] -> SeqExpr
-exprsToSeqExp = coerce
+-- exprsToSeqExp :: [Expr] -> SeqExpr
+-- exprsToSeqExp = coerce
 
-consSeqExpr :: Expr -> SeqExpr -> SeqExpr
-consSeqExpr expr (MkSeqExpr exprs) = exprsToSeqExp $ expr : exprs
+-- consSeqExpr :: Expr -> SeqExpr -> SeqExpr
+-- consSeqExpr expr (MkSeqExpr exprs) = exprsToSeqExp $ expr : exprs
 
 -- TODO: tweak the grammar to distinguish between integers and non-integers
 data Literal

--- a/lam4-backend/src/Lam4/Expr/ConcreteSyntax.hs
+++ b/lam4-backend/src/Lam4/Expr/ConcreteSyntax.hs
@@ -44,6 +44,7 @@ data Expr
   | Let        Name Expr Expr
   | Letrec     Name Expr Expr
   | Sig        [Name] [Expr]                       -- Sig parents relations
+  | Join       Expr Expr                           -- Relational join (similar to record projection)
   | Relation   Name Name Relatum (Maybe Text)      -- Relation relName relParentSigName relatum description
   deriving stock (Eq, Show, Ord)
 
@@ -71,7 +72,6 @@ data BinOp
   | Gte
   | Equals
   | NotEquals
-  | Join
    deriving stock (Eq, Show, Ord)
 
 data UnaryOp = Not | UnaryMinus

--- a/lam4-backend/src/Lam4/Expr/ConcreteSyntax.hs
+++ b/lam4-backend/src/Lam4/Expr/ConcreteSyntax.hs
@@ -36,7 +36,7 @@ data Expr
   | Unary      UnaryOp Expr
   | BinExpr    BinOp Expr Expr
   | IfThenElse Expr Expr Expr
-  -- | ListExpr   ListOp [Expr]
+  -- | ListExpr   ListOp [Expr] -- TODO: Not Yet Implemented
   | FunApp     Expr [Expr]
   | PredApp    Expr [Expr]
   | Fun        [Name] Expr (Maybe OriginalRuleRef) -- Function

--- a/lam4-backend/src/Lam4/Expr/ConcreteSyntax.hs
+++ b/lam4-backend/src/Lam4/Expr/ConcreteSyntax.hs
@@ -20,7 +20,7 @@ data BuiltinTypeForRelation = BuiltinTypeString | BuiltinTypeInteger | BuiltinTy
       In the future, the structure will be more complicated --- want to be able to support things like `§10(1)(a)`
 -}
 newtype OriginalRuleRef
-  = MkOriginalRuleRef Integer
+  = MkOriginalRuleRef Text
   deriving newtype (Eq, Ord)
   deriving stock (Show)
 
@@ -35,16 +35,16 @@ data Expr
   | Literal    Literal
   | Unary      UnaryOp Expr
   | BinExpr    BinOp Expr Expr
+  | IfThenElse Expr Expr Expr
   -- | ListExpr   ListOp [Expr]
   | FunApp     Expr [Expr]
   | PredApp    Expr [Expr]
-  | Join       Expr Expr
   | Fun        [Name] Expr (Maybe OriginalRuleRef) -- Function
   | Predicate  [Name] Expr (Maybe OriginalRuleRef) -- Differs from a function when doing symbolic evaluation. Exact way in which they should differ is WIP.
   | Let        Name Expr Expr
   | Letrec     Name Expr Expr
   | Sig        [Name] [Expr]                       -- Sig parents relations
-  | Relation   Relatum (Maybe Text)                -- Relation relatum description
+  | Relation   Name Name Relatum (Maybe Text)      -- Relation relName relParentSigName relatum description
   deriving stock (Eq, Show, Ord)
 
 -- TODO: tweak the grammar to distinguish between integers and non-integers
@@ -64,12 +64,14 @@ data BinOp
   | Plus
   | Minus
   | Mult
+  | Div
   | Lt
   | Lte
   | Gt
   | Gte
   | Equals
   | NotEquals
+  | Join
    deriving stock (Eq, Show, Ord)
 
 data UnaryOp = Not | UnaryMinus

--- a/lam4-backend/src/Lam4/Expr/ConcreteSyntax.hs
+++ b/lam4-backend/src/Lam4/Expr/ConcreteSyntax.hs
@@ -5,8 +5,8 @@ TODO:
 
 module Lam4.Expr.ConcreteSyntax where
 
-import Base
-import Lam4.Expr.Name (Name(..))
+import           Base
+import           Lam4.Expr.Name (Name (..))
 
 data Relatum
   = CustomType  Name
@@ -14,7 +14,7 @@ data Relatum
   deriving stock (Eq, Show, Ord, Generic)
 
 data BuiltinTypeForRelation = BuiltinTypeString | BuiltinTypeInteger | BuiltinTypeBoolean
-  deriving stock (Eq, Show, Ord, Generic) 
+  deriving stock (Eq, Show, Ord, Generic)
 
 
 -- newtype Program = MkProgram [Expr]
@@ -23,18 +23,20 @@ data BuiltinTypeForRelation = BuiltinTypeString | BuiltinTypeInteger | BuiltinTy
 
 -- TODO: think more about Sigs!
 data Expr
-  = Unary      UnaryOp Expr
-  | BinExpr    BinOp Expr Expr 
+  = Var Name
+  | Literal    Literal
+  | Unary      UnaryOp Expr
+  | BinExpr    BinOp Expr Expr
   -- | ListExpr   ListOp [Expr]
-  | Let        Name Expr Expr
   | FunApp     Expr [Expr]
   | PredApp    Expr [Expr]
   | Join       Expr Expr
   | Fun        [Name] Expr          -- Function
-  | Predicate  [Name] Expr          -- Differs from a function when doing symbolic evaluation 
+  | Predicate  [Name] Expr          -- Differs from a function when doing symbolic evaluation
+  | Let        Name Expr Expr
+  | Letrec     Name Expr Expr
   | Sig        [Name] [Expr]        -- Sig parents relations
   | Relation   Relatum (Maybe Text) -- Relation relatum description
-  | Literal    Literal
   deriving stock (Eq, Show, Ord)
 
 -- TODO: tweak the grammar to distinguish between integers and non-integers
@@ -62,6 +64,6 @@ data BinOp
   | NotEquals
    deriving stock (Eq, Show, Ord)
 
-data UnaryOp = Not | UnaryMinus 
+data UnaryOp = Not | UnaryMinus
   deriving stock (Eq, Show, Ord)
 

--- a/lam4-backend/src/Lam4/Expr/Name.hs
+++ b/lam4-backend/src/Lam4/Expr/Name.hs
@@ -1,24 +1,30 @@
+{-# LANGUAGE TemplateHaskell, QuasiQuotes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 {- |
 The treatment of names is adapted from http://blog.vmchale.com/article/intern-identifiers
 -}
 
-module Lam4.Expr.Name (Name (..), Unique (..)) where
+module Lam4.Expr.Name (Name(..), Unique) where
 
 import Base.Text qualified as T
+import Base (makeFieldLabelsNoPrefix)
 
-newtype Unique = Unique {unUnique :: Int}
-  deriving newtype (Eq, Ord, Show)
+type Unique = Int
 
-data Name = Name
+data Name = MkName
   { name :: T.Text
   , unique :: !Unique
   }
+makeFieldLabelsNoPrefix ''Name
 
 instance Eq Name where
-  (==) (Name _ u) (Name _ u') = u == u'
+  (==) (MkName _ u) (MkName _ u') = u == u'
 
 instance Ord Name where
-  compare (Name _ u) (Name _ u') = compare u u'
+  compare (MkName _ u) (MkName _ u') = compare u u'
 
 instance Show Name where
-    show (Name t u) = show t <> "_" <> show u
+    show (MkName t u) = show t <> "_" <> show u

--- a/lam4-backend/src/Lam4/Expr/Parser.hs
+++ b/lam4-backend/src/Lam4/Expr/Parser.hs
@@ -208,7 +208,7 @@ parseJoin ::  A.Object -> Parser Expr
 parseJoin node = do
   left <- parseExpr =<< node .: "left"
   right <- parseExpr =<< node .: "right"
-  pure $ BinExpr Join left right
+  pure $ Join left right
 
 parseBinOp :: A.Object -> Parser BinOp
 parseBinOp opObj = do

--- a/lam4-backend/src/Lam4/Expr/Parser.hs
+++ b/lam4-backend/src/Lam4/Expr/Parser.hs
@@ -11,6 +11,10 @@
       4. is valid, according to the other static semantic checks / validators
 
 In short: the expression conforms, not just to the Lam4 grammar, but also to its semantics.
+
+The parsing/translation in Parser.hs preserves well-scopedness etc
+  because the translation maps constructs in the Langium grammar to concrete syntax in a 1-to-1 way.
+  The NamedElements are basically just relabelled with unique integers.
 -}
 
 module Lam4.Expr.Parser (
@@ -89,8 +93,9 @@ parseProgram program = do
       -- list of JSON paths for every NamedElement in the program
       nodePaths = elementValues ^.. folded % cosmos % ix "nodePath" % _String
 
-  -- Make Env of nodePaths => Uniques
-  -- All that's needed, for now, is *some* canonical order on the Uniques
+  {- Make Env of nodePaths => Uniques
+    All that's needed, for now, is *some* canonical order on the Uniques
+  -}
   setEnv (zip nodePaths [1 .. ])
   parseDecls elementObjects
 

--- a/lam4-backend/src/Lam4/Expr/Parser.hs
+++ b/lam4-backend/src/Lam4/Expr/Parser.hs
@@ -1,0 +1,369 @@
+{- | Parses the JSON representation of (the concrete syntax of)
+      an input Lam4 expression from Langium frontend
+
+      ---------------------------
+      Assumptions / preconditions
+      ---------------------------
+      This *input Lam4 expression*
+      1. is valid, according to Langium parser
+      2. is valid, according to scoper
+      3. is valid, according to type checker
+      4. is valid, according to the other static semantic checks / validators
+
+In short: the expression conforms, not just to the Lam4 grammar, but also to its semantics.
+-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Lam4.Expr.Parser (
+  parseProgramByteStr, 
+  parseProgram, 
+  parseExpr) 
+  where
+
+import           Base
+import           Base.Aeson               (FromJSON, _Integer, _Object, _String,
+                                           values)
+import qualified Base.Aeson               as A
+import qualified Data.Set                 as Set
+import           Base.ByteString          (ByteString)
+import           Base.Plated              (Plated, cosmos, plate)
+import qualified Base.Text                as T
+-- import qualified Data.List.NonEmpty as NE
+import qualified Data.Foldable            as F
+import           Lam4.Expr.ConcreteSyntax
+import           Lam4.Expr.Name           (Name (..))
+import           Lam4.Parser.Monad
+import           Lam4.Parser.Type
+
+instance Plated A.Value where
+  plate f (A.Object o) = A.Object <$> traverse f o
+  plate f (A.Array a)  = A.Array <$> traverse f a
+  plate _ xs           = pure xs
+  {-# INLINE plate #-}
+
+-- | The Langium-parser ASTNode `$type`s that correspond to recursive exprs
+recursiveTypes :: Set Text
+recursiveTypes = Set.fromList ["LetExpr", "FunDecl", "PredicateDecl"]
+
+{----------------------
+    Ref
+-----------------------}
+
+newtype Ref = MkRef A.Object
+  deriving newtype (Eq, Show, Ord, FromJSON)
+
+parseRefToVar :: Ref -> Parser Expr
+parseRefToVar ref = Var <$> relabelRef ref
+
+relabelBareRef :: Ref -> Parser Name
+relabelBareRef = relabelRefHelper getRef getRefText
+  where
+    getRef node = node ^? ix "$ref" % _String
+    getRefText node = node ^? ix "$refText" % _String
+
+{- | Relabel an object that is a ('wrapped') `Ref` to a `Name` -}
+relabelRef :: Ref -> Parser Name
+relabelRef = relabelRefHelper getRef getRefText
+  where
+    getRef node = node ^? ix "value" % ix "$ref" % _String
+    getRefText node = node ^? ix "value" % ix "$refText" % _String
+
+relabelRefHelper :: (A.Object -> Maybe RefPath) -> (A.Object -> Maybe Text) -> Ref -> Parser Name
+relabelRefHelper getRef getRefText (MkRef node) = do
+  let refPath = getRef node
+      refText = getRefText node
+  case (refPath, refText) of
+    (Just refPath', Just refText') -> do
+      refUnique <- refPathToUnique refPath'
+      pure $ MkName refText' refUnique
+    _ -> error $ ppShow node <> " impossible"
+
+{----------------------
+    Program
+-----------------------}
+
+parseProgramByteStr :: ByteString -> Parser [Decl]
+parseProgramByteStr bs =
+  case bs ^? _Object of
+    Just programObject -> parseProgram programObject
+    Nothing            -> pure []
+
+parseProgram :: A.Object -> Parser [Decl]
+parseProgram program = do
+  let
+      elementValues = program ^.. ix "elements" % values
+      elementObjects = elementValues ^.. folded % _Object
+      -- list of JSON paths for every NamedElement in the program
+      nodePaths = elementValues ^.. folded % cosmos % ix "nodePath" % _String
+
+  -- Make Env of nodePaths => Uniques
+  -- All that's needed, for now, is *some* canonical order on the Uniques
+  setEnv (zip nodePaths [1 .. ])
+  parseDecls elementObjects
+
+mkDecl :: Text -> Name -> Expr -> Decl
+mkDecl typeOfNode name expr =
+  if has (contains typeOfNode) recursiveTypes
+  then Rec name expr
+  else NonRec name expr
+
+parseDecls :: [A.Object] -> Parser [Decl]
+parseDecls = traverse parseDecl
+
+parseDecl :: A.Object -> Parser Decl
+parseDecl obj = do
+  expr <- parseExpr obj
+  exprType <- obj .: "$type"
+  name <- getName obj
+  pure $ mkDecl exprType name expr
+
+{----------------------
+    parseExpr
+-----------------------}
+
+parseExpr :: A.Object -> Parser Expr
+parseExpr node = do
+  (node .: "$type" :: Parser Text) >>= \case
+    "Ref"            -> parseRefToVar            (coerce node)
+
+    "SigDecl"        -> parseSigE           node
+
+    -- literals
+    "IntegerLiteral" -> parseIntegerLiteral node
+    "StringLiteral"  -> parseLiteral StringLiteral node
+    "BooleanLiteral" -> parseLiteral BooleanLiteral node
+
+    "LetExpr"        -> parseLet            node
+    "FunDecl"        -> parseFunE           node
+    "AnonFunction"   -> parseAnonFun node
+    "PredicateDecl"  -> parsePredicateE     node
+
+    "FunctionApplication"       -> parseFunApp node
+    "InfixPredicateApplication" -> parsePredicateApp node
+
+    "BinExpr"        -> parseBinExpr        node
+    "Join"           -> parseJoin           node
+    "UnaryExpr"      -> parseUnaryExpr      node
+    "IfThenElseExpr" -> parseIfThenElse     node
+
+    typestr          -> error $ T.unpack typestr <> " not yet implemented"
+
+
+{----------------------
+    Relation related
+-----------------------}
+
+parseBuiltinTypeForRelation :: A.Value -> Parser BuiltinTypeForRelation
+parseBuiltinTypeForRelation = liftBase . A.parseJSON
+
+instance FromJSON BuiltinTypeForRelation where
+  parseJSON :: A.Value -> AesonParser BuiltinTypeForRelation
+  parseJSON = A.withText "BuiltinTypeForRelation" $ \case
+    "Integer" -> pure BuiltinTypeInteger
+    "String"  -> pure BuiltinTypeString
+    "Boolean" -> pure BuiltinTypeBoolean
+    other     -> fail ("Unexpected type " <> T.unpack other)
+
+parseRelatum :: A.Object -> Parser Relatum
+parseRelatum node = do
+  (node .: "$type" :: Parser Text) >>= \case
+    "CustomTypeDef" -> do
+      name <- relabelBareRef $ coerce $ node `objAtKey` "annot"
+      pure $ CustomType name
+    "BuiltinType"   -> do
+      builtinType <- parseBuiltinTypeForRelation =<< (node .: "annot")
+      pure $ BuiltinType builtinType
+    _               -> error "unrecognized relatum"
+
+parseRelation :: Name -> A.Object -> Parser Expr
+parseRelation parentSigName relationNode = do
+    relationName <- getName relationNode
+    relatum     <- parseRelatum =<< relationNode .: "relatum"
+    description <- relationNode .:? "description"
+    pure $ Relation relationName parentSigName relatum description
+
+
+{----------------------
+    Sig
+-----------------------}
+
+-- i.e., without worrying about the name -- that's handled by parseDecl
+parseSigE ::  A.Object -> Parser Expr
+parseSigE sigNode = do
+  let
+    parentRefNodes = getObjectsAtField sigNode "parents"
+    relationNodes = getObjectsAtField sigNode "relations"
+  parents   <- traverse (relabelRef . MkRef) parentRefNodes
+  sigName   <- getName sigNode
+  relations <- traverse (parseRelation sigName) relationNodes
+  pure $ Sig parents relations
+
+
+{-----------------------------------
+    BinExpr, UnaryExpr, IfThenElse
+------------------------------------}
+
+parseBinExpr :: A.Object -> Parser Expr
+parseBinExpr node = do
+  op    <- parseBinOp =<< node .: "op"
+  left  <- parseExpr =<< node .: "left"
+  right <- parseExpr =<< node .: "right"
+  pure $ BinExpr op left right
+
+parseJoin ::  A.Object -> Parser Expr
+parseJoin node = do
+  left <- parseExpr =<< node .: "left"
+  right <- parseExpr =<< node .: "right"
+  pure $ BinExpr Join left right
+
+parseBinOp :: A.Object -> Parser BinOp
+parseBinOp opObj = do
+  opStr <- opObj .: "$type"
+  case opStr of
+    "OpOr"        -> pure Or
+    "OpAnd"       -> pure And
+    "OpPlus"      -> pure Plus
+    "OpMinus"     -> pure Minus
+    "OpMult"      -> pure Mult
+    "OpDiv"       -> pure Div
+    "OpLt"        -> pure Lt
+    "OpLte"       -> pure Lte
+    "OpGt"        -> pure Gt
+    "OpGte"       -> pure Gte
+    "OpEquals"    -> pure Equals
+    "OpNotEquals" -> pure NotEquals
+    _             -> error $ "Unknown operator: " <> opStr
+
+parseUnaryExpr :: A.Object -> Parser Expr
+parseUnaryExpr node = do
+    op <- node .: "op"
+    value <- parseExpr $ getValueFieldOfNode node
+    case op of
+        "OpMinus" -> pure $ Unary UnaryMinus value
+        "OpNot"   -> pure $ Unary Not value
+        _         -> error $ "Unknown unary operator: " <> op
+
+parseIfThenElse :: A.Object -> Parser Expr
+parseIfThenElse obj = do
+    condition <- parseExpr =<< obj .: "condition"
+    thenExpr  <- parseExpr =<< obj .: "then"
+    elseExpr  <- parseExpr =<< obj .: "else"
+    pure $ IfThenElse condition thenExpr elseExpr
+
+
+{------------------------
+    Let
+-------------------------}
+
+type Row = (Name, Expr)
+
+parseLet :: A.Object -> Parser Expr
+parseLet obj = do
+  rows <- traverse parseVarDecl $ obj `getObjectsAtField` "vars"
+  body <- parseExpr $ obj `objAtKey` "body"
+  makeNestedLet body rows
+    where
+      makeNestedLet :: Expr -> [Row] -> Parser Expr
+      makeNestedLet body rows = F.foldrM nestLet body rows
+
+      nestLet :: Row -> Expr -> Parser Expr
+      nestLet (name, valE) accE = pure $ Let name valE accE
+
+parseVarDecl :: A.Object -> Parser Row
+parseVarDecl varDecl = do
+  name <- getName varDecl
+  val <- parseExpr (getValueFieldOfNode varDecl)
+  pure (name, val)
+
+
+{------------------------
+    Function, Predicate
+-------------------------}
+
+parseOriginalRuleRef :: Maybe A.Object -> Parser (Maybe OriginalRuleRef)
+parseOriginalRuleRef (Just origRuleRef) = do
+  let ruleRef = origRuleRef ^?! ix "section" % _String
+  pure $ Just $ MkOriginalRuleRef ruleRef
+parseOriginalRuleRef Nothing = pure Nothing
+
+extractOriginalRuleRef :: A.Object -> Parser (Maybe OriginalRuleRef)
+extractOriginalRuleRef node = parseOriginalRuleRef (node ^? ix "originalRuleRef" % _Object)
+
+parseParam :: A.Object -> Parser Name
+parseParam = getName
+
+parseAnonFun :: A.Object -> Parser Expr
+parseAnonFun anonFun = do
+  paramNames <- traverse parseParam anonFunParams
+  body <- parseExpr =<< anonFun .: "body"
+  pure $ Fun paramNames body Nothing
+    where
+      anonFunParams = anonFun ^.. ix "params" % values % cosmos % ix "param" % _Object
+
+parseFunE :: A.Object -> Parser Expr
+parseFunE fun = do
+  paramNames <- traverse parseParam (fun `getObjectsAtField` "params")
+  body <- parseExpr =<< fun .: "body"
+  originalRuleRef <- extractOriginalRuleRef fun
+  pure $ Fun paramNames body originalRuleRef
+
+{- | Treating predicate exprs separately from function expressions,
+even though the current code is similar,
+because predicates will likely be treated differently in symbolic execution
+(and hence the specifications for functions versus predicates are likely to diverge)
+-}
+parsePredicateE :: A.Object -> Parser Expr
+parsePredicateE predicate = do
+  paramNames <- traverse parseParam (getPredicateParams predicate)
+  body <- parseExpr =<< predicate .: "body"
+  originalRuleRef <- extractOriginalRuleRef predicate
+  pure $ Predicate paramNames body originalRuleRef
+    where
+      getPredicateParams predicateNode = predicateNode ^.. ix "params" % values % ix "param" % _Object
+
+parsePredicateApp ::  A.Object -> Parser Expr
+parsePredicateApp predApp = do
+    predicate <- parseExpr =<< predApp .: "predicate"
+    args <- traverse parseExpr (predApp `getObjectsAtField` "args")
+    pure $ PredApp predicate args
+
+parseFunApp :: A.Object -> Parser Expr
+parseFunApp funApp = do
+    func <- parseExpr =<< funApp .: "func"
+    args <- traverse parseExpr (funApp `getObjectsAtField` "args")
+    pure $ FunApp func args
+
+
+{----------------------
+    Literals
+-----------------------}
+
+parseIntegerLiteral :: A.Object -> Parser Expr
+parseIntegerLiteral literalNode = do
+    let literalVal = literalNode ^? ix "value" % _String % _Integer
+    case literalVal of
+      Just litVal -> pure . Literal $ IntegerLiteral litVal
+      Nothing -> error $ "Failed to parse integer value. Node: " <> show literalNode
+
+parseLiteral :: FromJSON t => (t -> Literal) -> A.Object -> Parser Expr
+parseLiteral literalExprCtor literalNode = do
+    literalVal <- literalNode .: "value"
+    return $ Literal $ literalExprCtor literalVal
+
+{----------------------
+    Utils
+-----------------------}
+
+{- | Gets/Makes the Name of an NamedElement node
+      that has both a `name` and `nodePath` key.
+    Assumes that the node's refPath has already been stashed in the environment
+-}
+getName :: A.Object -> Parser Name
+getName node = do
+  name :: Text <- node .: "name"
+  nodePath :: Text <- node .: "nodePath"
+  unique <- refPathToUnique nodePath
+  pure $ MkName name unique
+
+getValueFieldOfNode :: (JoinKinds (IxKind s) A_Prism k, Is k An_AffineFold, Ixed s,  A.AsValue (IxValue s), IsString (Index s)) => s -> A.Object
+getValueFieldOfNode node = node `objAtKey` "value"

--- a/lam4-backend/src/Lam4/Parser/Monad.hs
+++ b/lam4-backend/src/Lam4/Parser/Monad.hs
@@ -19,6 +19,7 @@ module Lam4.Parser.Monad
   -- * RefPath related
   -- , processRefPath
   , refPathToUnique
+  , refPathToMaybeUnique
 
   -- * Env related
   , getEnv
@@ -41,18 +42,6 @@ import           Lam4.Parser.Type
 
 initialParserState :: ParserState
 initialParserState = MkParserState emptyEnv 0
-
--- parseNodeObject ::
---   ParserError
---   -> Parser a
---   -> (A.Object -> ParserState)
---   -> A.Value -> AesonParser a
--- parseNodeObject errorStr parser restOfParserState = A.withObject errorStr (evalParserWithObj parser restOfParserState)
-
--- -- TODO: Figure out how to anti-unify `runParserWithObj` and `runParser` (maybe with type applications?)
--- evalParserWithObj :: Parser a -> (A.Object -> ParserState) -> (A.Object -> AesonParser a)
--- evalParserWithObj (MkParser parser) withRestOfParserState =
---   \object -> fst <$> parser (withRestOfParserState object)
 
 runParser ::
   Parser a
@@ -93,6 +82,10 @@ refPathToUnique refpath = do
     Nothing -> error "the input program is assumed to be well-scoped"
     Just v  -> pure v
 
+refPathToMaybeUnique :: RefPath -> Parser (Maybe Unique)
+refPathToMaybeUnique refpath = lookupInEnv refpath <$> getEnv
+
+
 -- processRefPath :: RefPath -> CSTParser ()
 -- processRefPath refpath = do
 --   env <- getEnv
@@ -132,6 +125,21 @@ extendEnv = flip M.union
 -----------------------------------------------------------
 -- Aug 10: Commenting out stuff that I'm not sure is needed
 -----------------------------------------------------------
+
+-- parseNodeObject ::
+--   ParserError
+--   -> Parser a
+--   -> (A.Object -> ParserState)
+--   -> A.Value -> AesonParser a
+-- parseNodeObject errorStr parser restOfParserState = A.withObject errorStr (evalParserWithObj parser restOfParserState)
+
+-- -- TODO: Figure out how to anti-unify `runParserWithObj` and `runParser` (maybe with type applications?)
+-- evalParserWithObj :: Parser a -> (A.Object -> ParserState) -> (A.Object -> AesonParser a)
+-- evalParserWithObj (MkParser parser) withRestOfParserState =
+--   \object -> fst <$> parser (withRestOfParserState object)
+
+----------------------
+
 
 -- insertEnv :: RefPath -> Unique -> CSTParser ()
 -- insertEnv refPath uniqueV = do

--- a/lam4-backend/src/Lam4/Parser/Monad.hs
+++ b/lam4-backend/src/Lam4/Parser/Monad.hs
@@ -1,0 +1,94 @@
+module Lam4.Parser.Monad
+  (
+    runParser
+
+  -- * Unique related
+  , getFresh
+
+  -- * RefPath related
+  , processRefPath
+  , refPathToUnique
+
+  -- * Env related
+  , getEnv
+  , withEnv
+  , emptyEnv
+  , lookupInEnv
+  , extendEnv
+  , insertEnv
+  )
+where
+
+import           Base
+import           Base.Map         as M
+import           Lam4.Expr.Name   (Unique)
+import           Lam4.Parser.Type
+
+initialParserState :: ParserState
+initialParserState = MkParserState emptyEnv 0
+
+runParser :: CSTParser a -> (Either ParserError a, ParserState)
+runParser (MkParser parser) = parser initialParserState
+
+{--------------------
+    Unique related
+---------------------}
+
+getFresh :: CSTParser Unique
+getFresh = do #maxUnique <%= (+ 1)
+
+
+{--------------------
+    RefPath x Env
+---------------------}
+
+{- | Get the Unique corresponding to the RefPath of a `NamedElement` from Langium Parser
+Assumes that the NamedElements have been processed -}
+refPathToUnique :: RefPath -> CSTParser Unique
+refPathToUnique refpath = do
+  env <- getEnv
+  case lookupInEnv refpath env of
+    Nothing -> throwError "the input program is assumed to be well-scoped"
+    Just v  -> pure v
+
+processRefPath :: RefPath -> CSTParser ()
+processRefPath refpath = do
+  env <- getEnv
+  unless (M.member refpath env) $
+    do
+      newUnique <- getFresh
+      insertEnv refpath newUnique
+
+
+{--------------------
+    Env Operations
+---------------------}
+
+getEnv :: CSTParser Env
+getEnv = use #refPathEnv
+
+insertEnv :: RefPath -> Unique -> CSTParser ()
+insertEnv refPath uniqueV = do
+  env <- getEnv
+  let newEnv = M.insert refPath uniqueV env
+  assign' #refPathEnv newEnv
+
+lookupInEnv :: RefPath -> Env -> Maybe Unique
+lookupInEnv = M.lookup
+
+-- | An empty Env.
+emptyEnv :: Env
+emptyEnv = M.empty
+
+-- | Second environment wins over first.
+extendEnv :: Env -> Env -> Env
+extendEnv = flip M.union
+
+-- adapted from Simala's evaluator
+withEnv :: Env -> CSTParser a -> CSTParser a
+withEnv env m = do
+  savedEnv <- getEnv
+  assign' #refPathEnv env
+  r <- m
+  assign' #refPathEnv savedEnv
+  pure r

--- a/lam4-backend/src/Lam4/Parser/Monad.hs
+++ b/lam4-backend/src/Lam4/Parser/Monad.hs
@@ -3,23 +3,25 @@ module Lam4.Parser.Monad
     runParser
 
   -- * Unique related
-  , getFresh
+  -- , getFresh
 
   -- * RefPath related
-  , processRefPath
+  -- , processRefPath
   , refPathToUnique
 
   -- * Env related
   , getEnv
-  , withEnv
+  , setEnv
   , emptyEnv
   , lookupInEnv
   , extendEnv
-  , insertEnv
+  -- , withEnv
+  -- , insertEnv
   )
 where
 
 import           Base
+import qualified Base.Aeson       as AE
 import           Base.Map         as M
 import           Lam4.Expr.Name   (Unique)
 import           Lam4.Parser.Type
@@ -27,16 +29,8 @@ import           Lam4.Parser.Type
 initialParserState :: ParserState
 initialParserState = MkParserState emptyEnv 0
 
-runParser :: CSTParser a -> (Either ParserError a, ParserState)
+runParser :: Parser a -> AE.Parser (Either ParserError a, ParserState)
 runParser (MkParser parser) = parser initialParserState
-
-{--------------------
-    Unique related
----------------------}
-
-getFresh :: CSTParser Unique
-getFresh = do #maxUnique <%= (+ 1)
-
 
 {--------------------
     RefPath x Env
@@ -44,34 +38,36 @@ getFresh = do #maxUnique <%= (+ 1)
 
 {- | Get the Unique corresponding to the RefPath of a `NamedElement` from Langium Parser
 Assumes that the NamedElements have been processed -}
-refPathToUnique :: RefPath -> CSTParser Unique
+refPathToUnique :: RefPath -> Parser Unique
 refPathToUnique refpath = do
   env <- getEnv
   case lookupInEnv refpath env of
     Nothing -> throwError "the input program is assumed to be well-scoped"
     Just v  -> pure v
 
-processRefPath :: RefPath -> CSTParser ()
-processRefPath refpath = do
-  env <- getEnv
-  unless (M.member refpath env) $
-    do
-      newUnique <- getFresh
-      insertEnv refpath newUnique
+-- processRefPath :: RefPath -> CSTParser ()
+-- processRefPath refpath = do
+--   env <- getEnv
+--   unless (M.member refpath env) $
+--     do
+--       newUnique <- getFresh
+--       insertEnv refpath newUnique
 
 
 {--------------------
     Env Operations
 ---------------------}
 
-getEnv :: CSTParser Env
+getEnv :: Parser Env
 getEnv = use #refPathEnv
 
-insertEnv :: RefPath -> Unique -> CSTParser ()
-insertEnv refPath uniqueV = do
-  env <- getEnv
-  let newEnv = M.insert refPath uniqueV env
+-- | Makes an env from the supplied AssocList and sets the monad's Env to that
+setEnv :: [(RefPath, Unique)] -> Parser ()
+setEnv assocList = do
+  let newEnv = M.fromList assocList
   assign' #refPathEnv newEnv
+  assign' #maxUnique (length assocList)
+
 
 lookupInEnv :: RefPath -> Env -> Maybe Unique
 lookupInEnv = M.lookup
@@ -84,11 +80,30 @@ emptyEnv = M.empty
 extendEnv :: Env -> Env -> Env
 extendEnv = flip M.union
 
+
+-----------------------------------------------------------
+-- Aug 10: Commenting out stuff that I'm not sure is needed
+-----------------------------------------------------------
+
+-- insertEnv :: RefPath -> Unique -> CSTParser ()
+-- insertEnv refPath uniqueV = do
+--   env <- getEnv
+--   let newEnv = M.insert refPath uniqueV env
+--   assign' #refPathEnv newEnv
+
 -- adapted from Simala's evaluator
-withEnv :: Env -> CSTParser a -> CSTParser a
-withEnv env m = do
-  savedEnv <- getEnv
-  assign' #refPathEnv env
-  r <- m
-  assign' #refPathEnv savedEnv
-  pure r
+-- withEnv :: Env -> CSTParser a -> CSTParser a
+-- withEnv env m = do
+--   savedEnv <- getEnv
+--   assign' #refPathEnv env
+--   r <- m
+--   assign' #refPathEnv savedEnv
+--   pure r
+
+{--------------------
+    Unique related
+---------------------}
+
+-- TODO: may not need this
+-- getFresh :: CSTParser Unique
+-- getFresh = do #maxUnique <%= (+ 1)

--- a/lam4-backend/src/Lam4/Parser/Monad.hs
+++ b/lam4-backend/src/Lam4/Parser/Monad.hs
@@ -9,6 +9,8 @@ module Lam4.Parser.Monad
   , runMaybeParser
   , defaultInitialParserState
 
+  , throwError
+
   -- * JSON-related operations
   , (.:)
   , objAtKey
@@ -27,7 +29,7 @@ module Lam4.Parser.Monad
   )
 where
 
-import           Base
+import           Base               hiding (throwError)
 import           Base.Aeson         (_Array, _Object)
 import qualified Base.Aeson         as A
 import           Base.Map           as M
@@ -51,6 +53,14 @@ evalParserFromScratch parser = evalParser parser defaultInitialParserState
 
 defaultInitialParserState :: ParserState
 defaultInitialParserState = MkParserState emptyEnv 0
+
+{-| This is the unsafe @error@. 
+But that's OK, because any errors here are programmer errors,
+since user errors would already have been caught by the upstream
+parser, validator, scoper in the Langium framework.
+ -}
+throwError :: [Char] -> Parser a
+throwError = error
 
 {---------------------------
     JSON-related operations

--- a/lam4-backend/src/Lam4/Parser/Type.hs
+++ b/lam4-backend/src/Lam4/Parser/Type.hs
@@ -6,6 +6,7 @@ module Lam4.Parser.Type (
   ParserState(..),
   AesonParser,
   ParserError,
+  liftBase,
 
   -- * RefPath, Env
   RefPath,

--- a/lam4-backend/src/Lam4/Parser/Type.hs
+++ b/lam4-backend/src/Lam4/Parser/Type.hs
@@ -3,8 +3,9 @@
 module Lam4.Parser.Type (
   -- * Parser related
   Parser(..),
-  ParserError,
   ParserState(..),
+  AesonParser,
+  ParserError,
 
   -- * RefPath, Env
   RefPath,
@@ -43,18 +44,29 @@ type Env = Map RefPath Unique
 data ParserState = MkParserState
   { refPathEnv :: !Env
   , maxUnique  :: !Unique -- ^ for making fresh int vars
+  , input      :: A.Object
   }
   deriving stock (Show, Generic)
+
+type AesonParser = A.Parser
 
 -- | Concrete Syntax Parser monad, for parsing the concrete syntax json serialized from the Langium parser
 type Parser :: Type -> Type
 newtype Parser a
-  = MkParser (ParserState -> A.Parser ( Either ParserError a, ParserState) )
+  = MkParser (ParserState -> AesonParser (a, ParserState))
   deriving
-    (Functor, Applicative, Monad, MonadState ParserState, MonadError ParserError)
-    via ExceptT ParserError (StateT ParserState A.Parser)
+    (Functor, Applicative, Monad, MonadState ParserState)
+    via (StateT ParserState AesonParser)
+
+
+  -- = MkParser (ParserState -> A.Parser ( Either ParserError a, ParserState) )
+  -- deriving
+  --   (Functor, Applicative, Monad, MonadState ParserState, MonadError ParserError)
+  --   via ExceptT ParserError (StateT ParserState A.Parser)
+
 
 {-
+
 ExceptT ParserError (StateT ParserState A.Parser) a
 = StateT ParserState A.Parser (Either ParserError a)
 = ParserState -> A.Parser ( (Either ParserError a), ParserState) )

--- a/lam4-backend/src/Lam4/Parser/Type.hs
+++ b/lam4-backend/src/Lam4/Parser/Type.hs
@@ -1,33 +1,56 @@
 module Lam4.Parser.Type (
-    CSTParser
-  , CSTParserError
-  , CSTParserState
-  , Env            
-  ) where
+  -- * Parser related
+  CSTParser(..),
+  ParserError,
+  ParserState(..),
 
-import Base
-import Base.IntMap (IntMap)
--- import Lam4.Expr.Name (Name(..))
-import Lam4.Expr.ConcreteSyntax
+  -- * RefPath, Env
+  RefPath,
+  Env
+) where
 
-import Control.Monad.Identity()
-import Control.Monad.Except()
-import Control.Monad.Reader()
+import           Base
+import           Lam4.Expr.Name         (Unique)
 
--- | Env for identifier Names
-newtype Env = MkEnv (IntMap Expr)
-  deriving newtype (Eq, Show)
+import           Control.Monad.Except   ()
+import           Control.Monad.Identity ()
+import           Control.Monad.Reader   ()
 
-data CSTParserState = MkCSTParserState { env :: Env
-                                       , maxUnique :: !Int }
+{- | JSONPath for Refs
+
+Invariant: The path always starts with the global root element of the json-serialized concrete syntax we're parsing
+
+__Examples:__
+
+@
+"#/elements@2"
+"#/elements@3/params@0/param"
+"#/elements@0"
+@
+-}
+type RefPath = Text
+
+-- | Environment for Parser: map from RefPath to Uniques/Ints
+type Env = Map RefPath Unique
+
+{----------------------------
+    ParserState, Parser
+-----------------------------}
+
+data ParserState = MkParserState
+  { refPathEnv :: !Env
+  , maxUnique  :: !Unique -- ^ for making fresh int vars
+  }
   deriving stock (Show, Generic)
 
--- | CST means 'Concrete Syntax Parser'
+-- | Concrete Syntax Parser monad, for parsing the concrete syntax json serialized from the Langium parser
 type CSTParser :: Type -> Type
-newtype CSTParser a =
-  MkCSTParser (CSTParserState -> (Either CSTParserError a, CSTParserState))
-    deriving
-    (Functor, Applicative, Monad, MonadState CSTParserState, MonadError CSTParserError)
-    via  ExceptT CSTParserError (StateT CSTParserState Identity)
+newtype CSTParser a
+  = MkParser (ParserState -> (Either ParserError a, ParserState))
+  deriving
+    (Functor, Applicative, Monad, MonadState ParserState, MonadError ParserError)
+    via ExceptT ParserError (StateT ParserState Identity)
 
-type CSTParserError = String
+-- Prob won't really need much ParseError support
+-- since this is parsing something that's valid by lights of Langium parser and validator
+type ParserError = String

--- a/lam4-backend/src/Lam4/Parser/Type.hs
+++ b/lam4-backend/src/Lam4/Parser/Type.hs
@@ -43,10 +43,10 @@ type Env = Map RefPath Unique
     ParserState, Parser
 -----------------------------}
 
+-- | does NOT include the input object / value
 data ParserState = MkParserState
   { refPathEnv :: !Env
   , maxUnique  :: !Unique -- ^ for making fresh int vars
-  , input      :: A.Value
   }
   deriving stock (Show, Generic)
 

--- a/lam4-backend/src/Lam4/Parser/Type.hs
+++ b/lam4-backend/src/Lam4/Parser/Type.hs
@@ -66,17 +66,4 @@ instance MonadBase AesonParser Parser where
   liftBase aesonParser = MkParser $ \s -> fmap (, s) aesonParser
 
 
-  -- = MkParser (ParserState -> A.Parser ( Either ParserError a, ParserState) )
-  -- deriving
-  --   (Functor, Applicative, Monad, MonadState ParserState, MonadError ParserError)
-  --   via ExceptT ParserError (StateT ParserState A.Parser)
-{-
-
-ExceptT ParserError (StateT ParserState A.Parser) a
-= StateT ParserState A.Parser (Either ParserError a)
-= ParserState -> A.Parser ( (Either ParserError a), ParserState) )
--}
-
--- Prob won't really need much ParseError support
--- since this is parsing something that's valid by lights of Langium parser and validator
 type ParserError = String

--- a/lam4-frontend/src/language/lam4-json-serializer.ts
+++ b/lam4-frontend/src/language/lam4-json-serializer.ts
@@ -1,0 +1,23 @@
+import {DefaultJsonSerializer, LangiumDocument, type LangiumCoreServices, type AstNode, } from "langium";
+import type {JsonSerializeOptions} from "langium";
+import {isNamedElement, NamedElement} from "./generated/ast.js";
+
+
+export class WithNamedEltRefPathJsonSerializer extends DefaultJsonSerializer {
+    constructor(services: LangiumCoreServices) {
+        super(services);
+    }
+
+
+    override replacer(key: string, value: unknown, options: JsonSerializeOptions): unknown {
+        // Only need to add nodePath to NamedElements, 
+        // since refs will be only to NamedElements
+        if (Object.hasOwn(value as Object, "name")) {
+            // Might need to add more URI handling
+            (value as NamedElement & {"nodePath": string})["nodePath"] = "#" + this.astNodeLocator.getAstNodePath(value as AstNode);
+        }
+
+        return super.replacer(key, value, options);
+    }
+}
+

--- a/lam4-frontend/src/language/lam4-module.ts
+++ b/lam4-frontend/src/language/lam4-module.ts
@@ -4,6 +4,7 @@ import { Lam4GeneratedModule, Lam4GeneratedSharedModule } from './generated/modu
 import { Lam4Validator, registerValidationChecks } from './lam4-validator.js';
 import { Lam4ScopeProvider, Lam4ScopeComputation } from './lam4-scope.js';
 import { Lam4HoverProvider } from './lsp/lam4-hover-provider.js';
+import {WithNamedEltRefPathJsonSerializer} from "./lam4-json-serializer.js";
 
 /**
  * Declaration of custom services - add your own service classes here.
@@ -35,6 +36,9 @@ export const Lam4Module: Module<Lam4Services, PartialLangiumServices & Lam4Added
     },
     lsp: {
         HoverProvider: (services) => new Lam4HoverProvider(services)
+    },
+    serializer: {
+        JsonSerializer: (services) => new WithNamedEltRefPathJsonSerializer(services)
     }
 };
 

--- a/lam4-frontend/src/language/lam4.langium
+++ b/lam4-frontend/src/language/lam4.langium
@@ -1,6 +1,12 @@
 grammar Lam4
 
 /*
+=================
+Guiding Principle
+=================
+    * Keep the syntax relatively simple and constrained, while still being readable
+    * Use UI/UX, AI, program synthesis, formal methods etc to make it easy for non-technical users to understand and program in or do things with Lam4
+
 =========================
 How to see this in action
 ==========================

--- a/lam4-frontend/src/language/lam4.langium
+++ b/lam4-frontend/src/language/lam4.langium
@@ -119,7 +119,8 @@ GeneralMetadataBlock:
     '}'
 ;
 MetadataKey returns string:
-    ID | "description" | "description_for_semantic_parser"
+    ID | "description" 
+    // | "description_for_semantic_parser"
 ;
 
 MetadataKVPair:


### PR DESCRIPTION
The parser I'd written in the Langium framework exports a serialized-to-json version of the syntax (see, e..g, `node ./bin/cli toMinimalAst examples/chained_record_deref.l4`, from the `lam4/lam4-frontend` dir). This PR reads in that json into the Haskell backend.

Closes #44 .

The next steps:
* The grammar / concrete syntax so far is pretty simple --- will be adding constructs like `WHERE` in the near future, along with desugaring
* In particular, I will probably add records in (there's some subtle differences between records and relations)
* Add tests
* The Main.hs offers a simple, 'internal' CLI for this parser; this will be wired up to an evaluator in the near future
* Add a 'public', more stable CLI for `lam4`, in the root dir

Mostly tagging reviewers as an fyi --- not sure that this is worth an in-depth review

