### PR TITLE
Augment concrete syntax with (i) records, record projection and (ii) very WIP sketch of normative clauses

### DIFF
--- a/lam4-backend/src/Lam4/Expr/ConcreteSyntax.hs
+++ b/lam4-backend/src/Lam4/Expr/ConcreteSyntax.hs
@@ -2,11 +2,74 @@
 TODO:
 * Add Builtin list operations
 -}
-
 module Lam4.Expr.ConcreteSyntax where
 
 import           Base
 import           Lam4.Expr.Name (Name (..))
+
+
+data Decl =
+    NonRec Name Expr
+  | Rec    Name Expr
+  deriving stock Show
+
+{-
+TODO:
+  High priority
+    * Work out grammar for normative clauses
+    * Update Langium grammar and typechecker to match new constructs
+  Lower priority
+    * Add support for Transparency-related knobs
+-}
+data Expr
+  = Var        Name
+  | Literal    Literal
+  | Unary      UnaryOp Expr
+  | BinExpr    BinOp Expr Expr
+  | IfThenElse Expr Expr Expr
+  -- TODO: Not Yet Implemented / need to think more about what collection types to support
+  -- | ListExpr   ListOp [Expr]
+  | FunApp     Expr [Expr]
+  | Record     (Row Expr)                          -- record construction
+  | Project    Expr Name                           -- record projection
+  | Fun        [Name] Expr (Maybe OriginalRuleRef) -- Function
+  | Let        Name Expr Expr
+  | Letrec     Name Expr Expr
+
+  {-===========================
+    What follows is
+    EXPERIMENTAL or VERY WIP
+  ============================-}
+
+  -- WIP deontics-related things
+  | NormExpr   [NormativeClause]
+
+  {------------------------------------------------------------
+  Stuff that's more relevant for analysis / symbolic evaluation
+  --------------------------------------------------------------
+  An Alloy Sig is a set
+  Had added  sigs and relations
+  because they're useful for certain sorts of analyses;
+  but not sure that we really want them
+  -}
+  | Predicate  [Name] Expr (Maybe OriginalRuleRef) -- Differs from a function when doing symbolic evaluation. Exact way in which they should differ is WIP.
+  | PredApp    Expr [Expr]
+  | Sig        [Name] [Expr]                       -- Sig parents relations
+  | Join       Expr Expr                           -- Relational join
+  | Relation   Name Name Relatum (Maybe Text)      -- Relation relName relParentSigName relatum description
+  deriving stock (Eq, Show, Ord)
+
+type Row a = [(Name, a)]
+
+{- | References to where in the original source this corresponds to; e.g., §10.
+     WIP -- In the future, the structure will be more complicated.
+     Want to be able to support things like `§10(1)(a)`
+-}
+newtype OriginalRuleRef
+  = MkOriginalRuleRef Text
+  deriving newtype (Eq, Ord)
+  deriving stock (Show)
+
 
 data Relatum
   = CustomType  Name
@@ -15,38 +78,6 @@ data Relatum
 
 data BuiltinTypeForRelation = BuiltinTypeString | BuiltinTypeInteger | BuiltinTypeBoolean
   deriving stock (Eq, Show, Ord, Generic)
-
-{- | References to where in the original source this corresponds to; e.g., §10.
-      In the future, the structure will be more complicated --- want to be able to support things like `§10(1)(a)`
--}
-newtype OriginalRuleRef
-  = MkOriginalRuleRef Text
-  deriving newtype (Eq, Ord)
-  deriving stock (Show)
-
-data Decl =
-    NonRec Name Expr
-  | Rec    Name Expr
-  deriving stock Show
-
--- TODO: think more about Sigs!
-data Expr
-  = Var Name
-  | Literal    Literal
-  | Unary      UnaryOp Expr
-  | BinExpr    BinOp Expr Expr
-  | IfThenElse Expr Expr Expr
-  -- | ListExpr   ListOp [Expr] -- TODO: Not Yet Implemented
-  | FunApp     Expr [Expr]
-  | PredApp    Expr [Expr]
-  | Fun        [Name] Expr (Maybe OriginalRuleRef) -- Function
-  | Predicate  [Name] Expr (Maybe OriginalRuleRef) -- Differs from a function when doing symbolic evaluation. Exact way in which they should differ is WIP.
-  | Let        Name Expr Expr
-  | Letrec     Name Expr Expr
-  | Sig        [Name] [Expr]                       -- Sig parents relations
-  | Join       Expr Expr                           -- Relational join (similar to record projection)
-  | Relation   Name Name Relatum (Maybe Text)      -- Relation relName relParentSigName relatum description
-  deriving stock (Eq, Show, Ord)
 
 -- TODO: tweak the grammar to distinguish between integers and non-integers
 data Literal
@@ -77,3 +108,41 @@ data BinOp
 data UnaryOp = Not | UnaryMinus
   deriving stock (Eq, Show, Ord)
 
+
+{-===========================================================
+   Normative clauses
+=============================================================-}
+
+{- | WIP. Trying to synthesize
+  * "Modelling and Analysis of Normative Documents"
+  * "COIR: Verifying Normative Specifications of Complex Systems"
+  * The work on SLEEC
+-}
+data NormativeClause = NCDeontic Deontic
+                     | NCRef Name -- ^ Reference to another clause
+    deriving stock (Eq, Show, Ord)
+
+{-| Think of this, in the simplest case, as:
+
+      @
+      WHEN <trigger event>
+      THEN <agent>
+            MUST/MAY
+            <action>
+            BY/WITHIN
+            <deadline>
+      @
+-}
+data Deontic =
+  MkDeontic { deonticStatus :: DeonticStatus
+            , agent         :: WIP_NotSureYet
+            , trigger       :: Expr
+            , action        :: WIP_NotSureYet
+            , deadline      :: [WIP_NotSureYet]}
+  deriving stock (Eq, Show, Ord)
+
+data WIP_NotSureYet
+  deriving stock (Eq, Show, Ord)
+
+data DeonticStatus = Obligation | Permission
+  deriving stock (Eq, Show, Ord)

--- a/lam4-backend/src/Lam4/Expr/Parser.hs
+++ b/lam4-backend/src/Lam4/Expr/Parser.hs
@@ -249,7 +249,7 @@ parseIfThenElse obj = do
     Let
 -------------------------}
 
-type Row = (Name, Expr)
+type Binding = (Name, Expr)
 
 parseLet :: A.Object -> Parser Expr
 parseLet obj = do
@@ -257,13 +257,13 @@ parseLet obj = do
   body <- parseExpr $ obj `objAtKey` "body"
   makeNestedLet body rows
     where
-      makeNestedLet :: Expr -> [Row] -> Parser Expr
+      makeNestedLet :: Expr -> [Binding] -> Parser Expr
       makeNestedLet body rows = F.foldrM nestLet body rows
 
-      nestLet :: Row -> Expr -> Parser Expr
+      nestLet :: Binding -> Expr -> Parser Expr
       nestLet (name, valE) accE = pure $ Let name valE accE
 
-parseVarDecl :: A.Object -> Parser Row
+parseVarDecl :: A.Object -> Parser Binding
 parseVarDecl varDecl = do
   name <- getName varDecl
   val <- parseExpr (getValueFieldOfNode varDecl)


### PR DESCRIPTION
@inariksit : Here's the grammar --- ConcreteSyntax.hs -- I had promised to send you, as preparation for experiments on 'rendering' in natural language! Note that it's not currently in sync with the stuff in the Langium lam4-frontend -- the frontend grammar and type checker haven't yet been updated with the constructs I just added. 

We can talk more later about more detailed desiderata for the rendering. My rough inclination right now would be to borrow ideas from ACE and what John Camilleri has done, except maybe tweak things to sound more like what one would see in contracts / legal texts (see Tina Stark's and Ken Adams' textbooks).

The expression language fragment of this concrete syntax is a superset of the main branch L4 syntax (i.e., the latter is a subtype of the former), so it should be easy to port over / adapt any work on rendering Lam4 concrete syntax to main-branch L4.

There also more constructs that one could add, like `WHERE`, but I wanted to focus on the most important / foundational constructs to begin with.

I'll also add some notes / docs explaining the 'rendering' initiative, and why we thought it'd be better to start with a 'rendering' approach, instead of a CNL that also allows for writing, in a subsequent PR.

I've also tagged kosimikus, fendor, Meng, and Martin just so they're aware of the direction we are heading in.
