### PR TITLE
Tweak Lam4 concrete syntax to avoid unnecessary or unintentional differences from Simala syntax / semantics

### DIFF
--- a/lam4-backend/src/Lam4/Expr/ConcreteSyntax.hs
+++ b/lam4-backend/src/Lam4/Expr/ConcreteSyntax.hs
@@ -23,7 +23,7 @@ TODO:
 -}
 data Expr
   = Var        Name
-  | Literal    Literal
+  | Lit        Lit
   | Unary      UnaryOp Expr
   | BinExpr    BinOp Expr Expr
   | IfThenElse Expr Expr Expr
@@ -80,10 +80,10 @@ data BuiltinTypeForRelation = BuiltinTypeString | BuiltinTypeInteger | BuiltinTy
   deriving stock (Eq, Show, Ord, Generic)
 
 -- TODO: tweak the grammar to distinguish between integers and non-integers
-data Literal
-  = IntegerLiteral Integer
-  | BooleanLiteral Bool
-  | StringLiteral Text
+data Lit
+  = IntLit Int
+  | BoolLit Bool
+  | StringLit Text -- TODO: not clear that we need this
   deriving stock (Eq, Show, Ord)
 
 {-
@@ -95,14 +95,15 @@ data BinOp
   | And
   | Plus
   | Minus
+  | Modulo   -- ^ (integer) remainder
   | Mult
-  | Div
+  | Divide
   | Lt
-  | Lte
+  | Le
   | Gt
-  | Gte
-  | Equals
-  | NotEquals
+  | Ge      -- ^ greater-than-or-equal
+  | Eq      -- ^ equality (of Booleans, numbers or atoms)
+  | Ne      -- ^ inequality (of Booleans, numbers or atoms)
    deriving stock (Eq, Show, Ord)
 
 data UnaryOp = Not | UnaryMinus

--- a/lam4-backend/src/Lam4/Expr/Parser.hs
+++ b/lam4-backend/src/Lam4/Expr/Parser.hs
@@ -127,9 +127,9 @@ parseExpr node = do
     "SigDecl"        -> parseSigE           node
 
     -- literals
-    "IntegerLiteral" -> parseIntegerLiteral node
-    "StringLiteral"  -> parseLiteral StringLiteral node
-    "BooleanLiteral" -> parseLiteral BooleanLiteral node
+    "IntLit" -> parseIntegerLiteral node
+    "StringLiteral"  -> parseLiteral StringLit node
+    "BooleanLiteral" -> parseLiteral BoolLit node
 
     "LetExpr"        -> parseLet            node
     "FunDecl"        -> parseFunE           node
@@ -219,13 +219,14 @@ parseBinOp opObj = do
     "OpPlus"      -> pure Plus
     "OpMinus"     -> pure Minus
     "OpMult"      -> pure Mult
-    "OpDiv"       -> pure Div
+    "OpDiv"       -> pure Divide
     "OpLt"        -> pure Lt
-    "OpLte"       -> pure Lte
+    "OpLte"       -> pure Le
     "OpGt"        -> pure Gt
-    "OpGte"       -> pure Gte
-    "OpEquals"    -> pure Equals
-    "OpNotEquals" -> pure NotEquals
+    "OpGte"       -> pure Ge
+    "OpEquals"    -> pure Eq
+    "OpNotEquals" -> pure Ne
+    "OpModulo"    -> pure Modulo
     _             -> throwError $ "Unknown operator: " <> opStr
 
 parseUnaryExpr :: A.Object -> Parser Expr
@@ -334,15 +335,15 @@ parseFunApp funApp = do
 
 parseIntegerLiteral :: A.Object -> Parser Expr
 parseIntegerLiteral literalNode = do
-    let literalVal = literalNode ^? ix "value" % _String % _Integer
+    let literalVal = literalNode ^? ix "value" % _String % _Integer % to fromInteger
     case literalVal of
-      Just litVal -> pure . Literal $ IntegerLiteral litVal
+      Just litVal -> pure . Lit $ IntLit litVal
       Nothing -> throwError $ "Failed to parse integer value. Node: " <> ppShow literalNode
 
-parseLiteral :: FromJSON t => (t -> Literal) -> A.Object -> Parser Expr
+parseLiteral :: FromJSON t => (t -> Lit) -> A.Object -> Parser Expr
 parseLiteral literalExprCtor literalNode = do
     literalVal <- literalNode .: "value"
-    return $ Literal $ literalExprCtor literalVal
+    return $ Lit $ literalExprCtor literalVal
 
 {----------------------
     Utils


### PR DESCRIPTION
I'm trying to minimize differences when it comes to areas where Lam4's semantics coincides with that of Simala, so as to minimize unnecessary work when adapting, e.g., work on tooling that was done with Lam4 to `dsl`-L4.

If `dsl`-L4's concrete syntax ends up diverging in its naming conventions from Simala's, I'll tweak Lam4 concrete syntax accordingly, where possible.