### PR TITLE
Grammar, Concrete Syntax (and Parser.hs) tweaks

### DIFF
--- a/docs/proposal_normative_constructs_aug26_2024.md
+++ b/docs/proposal_normative_constructs_aug26_2024.md
@@ -196,19 +196,25 @@ And the normative DSL SLEEC, which has constructs of the `when <trigger> then <r
 
 For example, suppose jursidication A and jurisdication B agree that there's an obligation to do something, but disagree in what the penalties would be. There is a natural, modular way to encode that on the alternative syntax. You would declare the obligation, and then, e.g., encode that each of the jurisdictions had different reparations for that obligation in separate `IF ... THEN ...` statements.
 
+Common:
+
 ```lam4
 // File 1
 §3: GumSpittingProhibition
 ... CANNOT spit_gum // haven't added CANNOT in yet but you get the idea
 ```
 
-```jursidiction_A
+jursidiction_A:
+
+```lam4
 // import File 1 obligations
 IF GumSpittingProhibition IS_INFRINGED
 THEN Spitter MUST pay_1000_fine // This syntax takes some simplifying liberties re the agent
 ```
 
-```jursidiction_A
+jursidiction_B:
+
+```lam4
 // import File 1 obligations
 IF GumSpittingProhibition IS_INFRINGED
 THEN Spitter MUST pay_50_fine
@@ -216,13 +222,17 @@ THEN Spitter MUST pay_50_fine
 
 By contrast, the current L4 syntax does not give you natural way to represent this; in particular, that both jursidictions in some sense forbid *the same thing*, but differ in their penalties for it. You would have to encode this with *distinct* obligations and reparations, e.g.
 
-```jurisdiction_A
+jursidiction_A:
+
+```L4
 ... MUSTN'T spit_gum
 LEST pay_1000_fine
 // I don't know if the current L4 AST even allows you to do a MUSTN'T in this way though
 ```
 
-```jurisdiction_B
+jursidiction_B:
+
+```L4
 ... MUSTN'T spit_gum
 LEST pay_50_fine
 ```

--- a/lam4-backend/lam4-backend.cabal
+++ b/lam4-backend/lam4-backend.cabal
@@ -37,6 +37,7 @@ library
         Base
         Base.IntMap
         Base.Map
+        Base.NonEmpty
         Base.Plated
         Base.Text
         Base.Aeson

--- a/lam4-backend/src/Lam4/Expr/AbstractSyntax.hs
+++ b/lam4-backend/src/Lam4/Expr/AbstractSyntax.hs
@@ -6,6 +6,11 @@ import           Base.Grisette
 import           Lam4.Expr.Name (Name (..))
 import           Lam4.Expr.CommonSyntax
 
+newtype Decl = MyDecl (DeclF Expr)
+  deriving newtype (Eq, Show)
+  deriving Generic
+  deriving (Mergeable, ExtractSym, EvalSym) via (Default (DeclF Expr))
+
 data Expr
   = Var        Name
   | Lit        SymLit
@@ -18,8 +23,8 @@ data Expr
   | Record     (Row (Union Expr))                          -- record construction
   | Project    (Union Expr) Name                           -- record projection
   | Fun        [Name] (Union Expr) (Maybe OriginalRuleRef) -- Function
-  | Let        Name (Union Expr) (Union Expr)
-  | Letrec     Name (Union Expr) (Union Expr)
+  | Let        Decl Expr
+  -- | StatementBlock  (NonEmpty Statement)
 
   {-===========================
     What follows is
@@ -30,9 +35,9 @@ data Expr
   -- | NormExpr   [Norm]
 
   | Predicate  [Name] (Union Expr) (Maybe OriginalRuleRef) -- Differs from a function when doing symbolic evaluation. Exact way in which they should differ is WIP.
-  | PredApp    (Union Expr) [Union Expr]
+  -- | PredApp    (Union Expr) [Union Expr]
   -- no sig related constructs for now
-  deriving stock (Eq, Show, Ord, Generic)
+  deriving stock (Eq, Show, Generic)
   deriving (Mergeable, ExtractSym, EvalSym) via (Default Expr)
 
 
@@ -40,5 +45,5 @@ data SymLit
   = IntLit SymInteger
   | BoolLit SymBool
   -- | StringLit Text -- TODO: not clear that we need this
-  deriving stock (Eq, Show, Ord, Generic)
-  deriving (Mergeable, SymEq) via (Default SymLit)
+  deriving stock (Eq, Show, Generic)
+  deriving (Mergeable, EvalSym, ExtractSym, SymEq) via (Default SymLit)

--- a/lam4-backend/src/Lam4/Expr/CommonSyntax.hs
+++ b/lam4-backend/src/Lam4/Expr/CommonSyntax.hs
@@ -1,7 +1,16 @@
 module Lam4.Expr.CommonSyntax where
 
 import           Base
+import           Base.Grisette
 import           Lam4.Expr.Name (Name (..))
+
+
+-- | Basically a 'Binding'
+data DeclF a =
+    NonRec      Name a
+  | Rec         Name a
+  deriving stock (Show, Eq, Ord, Generic)
+
 
 type Row a = [(Name, a)]
 
@@ -13,9 +22,12 @@ newtype OriginalRuleRef
   = MkOriginalRuleRef Text
   deriving newtype (Eq, Ord)
   deriving stock (Show, Generic)
+  deriving (Mergeable, ExtractSym, EvalSym) via (Default OriginalRuleRef)
+
 
 data UnaryOp = Not | UnaryMinus
   deriving stock (Eq, Show, Ord, Generic)
+  deriving (Mergeable, ExtractSym, EvalSym) via (Default UnaryOp)
 
 -- | Binary operators. May want to distinguish between concrete and abstract versions in the future, but for now, the CST and AST use the same set of BinOps.
 data BinOp
@@ -34,12 +46,15 @@ data BinOp
   | Ne      -- ^ inequality (of Booleans, numbers or atoms)
   | Cons    -- ^ List Cons
    deriving stock (Eq, Show, Ord, Generic)
-
+  deriving (Mergeable, ExtractSym, EvalSym) via (Default BinOp)
 
 data Relatum
   = CustomType  Name
   | BuiltinType BuiltinTypeForRelation
   deriving stock (Eq, Show, Ord, Generic)
+  deriving (Mergeable, ExtractSym, EvalSym) via (Default Relatum)
 
 data BuiltinTypeForRelation = BuiltinTypeString | BuiltinTypeInteger | BuiltinTypeBoolean
   deriving stock (Eq, Show, Ord, Generic)
+  deriving (Mergeable, ExtractSym, EvalSym) via (Default BuiltinTypeForRelation)
+

--- a/lam4-backend/src/Lam4/Expr/Name.hs
+++ b/lam4-backend/src/Lam4/Expr/Name.hs
@@ -1,6 +1,7 @@
-{-# LANGUAGE TemplateHaskell, QuasiQuotes #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE QuasiQuotes          #-}
+{-# LANGUAGE TemplateHaskell      #-}
+{-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 {- |
@@ -9,16 +10,20 @@ The treatment of names is adapted from http://blog.vmchale.com/article/intern-id
 
 module Lam4.Expr.Name (Name(..), Unique) where
 
-import Base.Text qualified as T
-import Base (makeFieldLabelsNoPrefix)
+import           Base          (Generic, makeFieldLabelsNoPrefix)
+import           Base.Grisette
+import qualified Base.Text     as T
 
 type Unique = Int
 
 data Name = MkName
-  { name :: T.Text
+  { name   :: T.Text
   , unique :: !Unique
   }
+  deriving stock Generic
+  deriving (Mergeable, ExtractSym, EvalSym) via (Default Name)
 makeFieldLabelsNoPrefix ''Name
+
 
 instance Eq Name where
   (==) (MkName _ u) (MkName _ u') = u == u'


### PR DESCRIPTION
- Clean up concrete syntax: 
    - add block of statements as variant to Expr; 
    - make Let a Let Decl; inline deontic stuff). 
    - Remove TopLevelElement

- Change `Parser.hs` accordingly
- Fix derivations for symbolic types for AST
- Proposal: Fix formatting issue