### PR TITLE
Add basic support for records in type checker; add `then` separator for sequential composition of actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 This is a kind of rational reconstruction of the 'MathLang' dialect of L4. That is, it is, at its core, a functional expression language; but it aims to extend the MathLang work by incorporating solver / automated reasoning capabilities. It also differs from Natural L4 in offering a textual format with a more constrained surface syntax (with a 'no-code,' intuitive GUI for non-programmers on the roadmap).
 
+## How to build
+
+This will be simpler soon enough, once I've set up a Nix environment etc. But in the meantime:
+
+You basically have to set up two things:
+1. The Langium frontend: see the detailed instructions in the `lam4-frontend` readme
+2. The Langium backend:  see the detailed instructions in the `lam4-backend` readme
+
 ## Goals in the short term
 
 * things will be rough around the edges, and technical debt will be unavoidable --- but we'll be explicit about said debt

--- a/lam4-backend/README.md
+++ b/lam4-backend/README.md
@@ -1,0 +1,6 @@
+# To set up
+
+1. Use GHC 9.8.2
+2. Make sure you have a working Z3 available through PATH. The symbolic evaluator hasn't been built yet, but one of the dependencies, Grisette, may require it already
+
+Note that the parser for the Haskell backend may not be in sync with the latest Langium frontend grammar, in the sense that support for all the constructs in the Langium grammar may not yet have been implemented.

--- a/lam4-frontend/examples/chained_record_deref.l4
+++ b/lam4-frontend/examples/chained_record_deref.l4
@@ -8,4 +8,4 @@ STRUCTURE G {
 }
 
 F => Integer
-f(x) = x `s` c `s` b
+f(x) = x`s` c`s` b

--- a/lam4-frontend/examples/simple_atomic_actions_borrower_debt.l4
+++ b/lam4-frontend/examples/simple_atomic_actions_borrower_debt.l4
@@ -8,5 +8,5 @@ ACTION `Borrower makes one loan installment` = DO {
 
 ACTION `pay off debt` = DO {
     `Borrower makes one loan installment`
-    `Borrower makes one loan installment`
+    then `Borrower makes one loan installment`
 }

--- a/lam4-frontend/examples/simple_join_or_record_field_deref.l4
+++ b/lam4-frontend/examples/simple_join_or_record_field_deref.l4
@@ -2,6 +2,8 @@ STRUCTURE Applicant {
     publications: Integer
 }
 
+DEFINE someApplicant: Applicant = {| publications = 1000 |}
+
 Applicant => Integer
 numberOfPublications(applicant) = applicant`s` publications
 

--- a/lam4-frontend/package.json
+++ b/lam4-frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lam4",
-    "description": "Frontend for the Lam4 DSL",
+    "description": "Frontend for the Lam4 variant of the L4 DSL",
     "version": "0.0.1",
     "license": "MIT",
     "files": [

--- a/lam4-frontend/src/language/lam4-lang-utils.ts
+++ b/lam4-frontend/src/language/lam4-lang-utils.ts
@@ -1,7 +1,8 @@
 import { AstNode } from "langium";
-import { Join } from "./generated/ast.js";
+import { Project } from "./generated/ast.js";
 
 /** For when using the default reflection-using <isPred> utils is problematic (e.g. in the scoping phase) */
-export function isJoinExpr(node: AstNode): node is Join {
-  return node.$type === "Join"
+export function isProjectExpr(node: AstNode): node is Project {
+  return node.$type === "Project"
 }
+

--- a/lam4-frontend/src/language/lam4-scope.ts
+++ b/lam4-frontend/src/language/lam4-scope.ts
@@ -3,7 +3,7 @@ import { DefaultScopeComputation, AstNode, LangiumDocument, PrecomputedScopes, D
 import { Logger } from "tslog";
 import { SigDecl, RecordDecl, Project } from "./generated/ast.js";
 import {isProjectExpr} from "./lam4-lang-utils.js";
-import { getSigAncestors, inferType, TypeEnv } from "./type-system/infer.js";
+import { getRecordAncestors, inferType, TypeEnv } from "./type-system/infer.js";
 import { isRecordTTag, isSigTTag } from "./type-system/type-tags.js";
 
 const scopeLogger = new Logger({ 
@@ -76,16 +76,17 @@ export class Lam4ScopeProvider extends DefaultScopeProvider {
     return super.getScope(context);
   }
 
-  private scopeSigMembers(sig: SigDecl): Scope {
-    const allRelations = getSigAncestors(sig).flatMap((s: SigDecl) => s.relations);
-    scopeLogger.debug(`relations: ${allRelations.map(r => r.name)}`);
-    return this.createScopeForNodes(allRelations);
-  } 
+  // Sep 2024: Deprecating this for now, till I get clearer on what should be done with Sigs
+  // private scopeSigMembers(sig: SigDecl): Scope {
+  //   const allRelations = getSigAncestors(sig).flatMap((s: SigDecl) => s.relations);
+  //   scopeLogger.debug(`relations: ${allRelations.map(r => r.name)}`);
+  //   return this.createScopeForNodes(allRelations);
+  // } 
 
   private scopeRecordMembers(record: RecordDecl): Scope {
-    const allFields = getRecordAncestors(record).flatMap((record: RecordDecl) => record.rowTypes);
-
-    return this.createScopeForNodes(record.rowTypes);
+    const allRowTypes = getRecordAncestors(record).flatMap((record: RecordDecl) => record.rowTypes);
+    scopeLogger.debug(`rowtypes: ${allRowTypes.map(r => r.name)}`);
+    return this.createScopeForNodes(allRowTypes);
   }
 }
 

--- a/lam4-frontend/src/language/lam4.langium
+++ b/lam4-frontend/src/language/lam4.langium
@@ -280,13 +280,24 @@ Mult infers Expr:
     Project ({infer BinExpr.left=current} op=(OpMult | OpDiv) right=Project)*
 ;
 
-/* Projects or Selects the value of a from a record */
+// TODO: 's and `s don't work out of the box
+// Can prob allow for "'s" by customizing the TokenBuilder
+/* Projects or Selects the value of a from a record 
+
+(To be clear, the auto-linking/crossref for this won't work in the playground: https://github.com/eclipse-langium/langium/discussions/1502)
+*/
 Project infers Expr:
     FunctionApplication ({infer Project.left=current} '`s`' right=Ref)*
+    // Right can't be [NamedElement:ID]
+    // because we want the scoper to visit `left` first,
+    // so that if `left`'s reference will be resolved via the default scoper/linker, if that's possible.
+    // This allows us to then use that resolved reference
+    // as a base case in figuring out the reference for `right`
 ;
 
 /* ---------------------------------------------------
-Aug 24 2024: Join is currently disabled
+Aug 24 2024: Join is currently disabled; 
+am porting what I currently have for Join to Project
 -------------------------------------------------------
 TODO: Add a variant of this in the standard library for relational join in the other direction --- maybe use "`of`"
 

--- a/lam4-frontend/src/language/lam4.langium
+++ b/lam4-frontend/src/language/lam4.langium
@@ -434,7 +434,7 @@ ActionDecl:
 ;
 
 fragment PrimActionBlock: 'DO' '{'
-    actions+=PrimAction+
+    actions+=PrimAction ('then' actions+=PrimAction)*
 '}';
 
 fragment StatementBlock: 'DO' '{'

--- a/lam4-frontend/src/language/type-system/infer.ts
+++ b/lam4-frontend/src/language/type-system/infer.ts
@@ -63,7 +63,7 @@ import {
     ParamTypePair} from "../generated/ast.js";
 import { TypeTag, ErrorTypeTag, StringTTag, IntegerTTag, isBooleanTTag, FunctionDeclTTag, isFunctionDeclTTag, PredicateTTag, isPredicateTTag, SigTTag, BooleanTTag, FunctionParameterTypePair, PredicateParameterTypePair, isErrorTypeTag, isSigTTag, isRelationTTag, RelationTTag, UnitTTag, isUnitTTag, FunOrPredDeclTTag, ParamlessFunctionTTag, isParamlessFunctionTTag} from "./type-tags.js";
 import type {FunctionParameterTypePairSequence} from "./type-tags.js";
-import { isJoinExpr } from "../lam4-lang-utils.js";
+import { isProjectExpr } from "../lam4-lang-utils.js";
 
 import { zip } from "../../utils.js"
 import { match, P } from 'ts-pattern';
@@ -289,7 +289,7 @@ export function synthNewNode(env: TypeEnv, term: AstNode): TypeTag {
     // (probably has to do with how the ref resolution hasn't fully completed at this stage)
     if (term.$type === "Ref") {
         typeTag = synthRef(env, term as Ref);
-    } else if (isJoinExpr(term)) {
+    } else if (isProjectExpr(term)) {
         typeTag = synthJoin(env, term as Join);
 
     // Constructs whose types can be easily read off the term

--- a/lam4-frontend/src/language/type-system/infer.ts
+++ b/lam4-frontend/src/language/type-system/infer.ts
@@ -54,14 +54,20 @@ import {
     isPredicateDecl,
     Ref,
     Join,
+    Project,
     FunctionApplication,
     InfixPredicateApplication,
     isInfixPredicateApplication,
     UnaryExpr,
     PrimitiveTypeAnnot,
     VarBinding,
-    ParamTypePair} from "../generated/ast.js";
-import { TypeTag, ErrorTypeTag, StringTTag, IntegerTTag, isBooleanTTag, FunctionDeclTTag, isFunctionDeclTTag, PredicateTTag, isPredicateTTag, SigTTag, BooleanTTag, FunctionParameterTypePair, PredicateParameterTypePair, isErrorTypeTag, isSigTTag, isRelationTTag, RelationTTag, UnitTTag, isUnitTTag, FunOrPredDeclTTag, ParamlessFunctionTTag, isParamlessFunctionTTag} from "./type-tags.js";
+    VarDeclStmt,
+    ParamTypePair,
+    RecordDecl,
+    isRecordDecl,
+    IDOrBackTickedID,
+    isRowType} from "../generated/ast.js";
+import { TypeTag, ErrorTypeTag, StringTTag, IntegerTTag, isBooleanTTag, FunctionDeclTTag, isFunctionDeclTTag, PredicateTTag, isPredicateTTag, SigTTag, BooleanTTag, FunctionParameterTypePair, PredicateParameterTypePair, isErrorTypeTag, isSigTTag, isRelationTTag, RelationTTag, UnitTTag, isUnitTTag, FunOrPredDeclTTag, ParamlessFunctionTTag, isParamlessFunctionTTag, isRecordTTag, RecordTTag, RowTypeTTag} from "./type-tags.js";
 import type {FunctionParameterTypePairSequence} from "./type-tags.js";
 import { isProjectExpr } from "../lam4-lang-utils.js";
 
@@ -124,6 +130,11 @@ export function inferType(env: TypeEnv, term: AstNode): TypeTag {
     }
 }
 
+function synthRecord(env: TypeEnv, record: RecordDecl): TypeTag {
+    const rowTypeTags = record.rowTypes.map(rtNode => ({name: rtNode.name, 
+        rowType: inferType(env, rtNode.value)}));
+    return  new RecordTTag(record, rowTypeTags);
+}
 
 function synthTypeAnnot(env: TypeEnv, annot: TypeAnnot | PrimitiveTypeAnnot | BuiltinType): TypeTag {
     typecheckLogger.trace(`[synthTypeAnnot]`);
@@ -148,7 +159,12 @@ function synthTypeAnnot(env: TypeEnv, annot: TypeAnnot | PrimitiveTypeAnnot | Bu
         if (!customType) {
             return new ErrorTypeTag(typeAnnot, `Type annotation ${typeAnnot.annot} not found because of an issue with linking`);
         }
-        return new SigTTag(customType as SigDecl);
+
+        return customType.$type === "RecordDecl"
+                ? 
+                synthRecord(env, customType as RecordDecl)
+                : 
+                new SigTTag(customType as SigDecl);
     }
 
     function isBasecaseTypeAnnot(annot: TypeAnnot | PrimitiveTypeAnnot | BuiltinType): boolean {
@@ -184,7 +200,6 @@ function synthTypeAnnot(env: TypeEnv, annot: TypeAnnot | PrimitiveTypeAnnot | Bu
         return new ErrorTypeTag(annot, `Type annotation ${annot} not recognized`);
     }
 }
-
 
 function synthBinExpr(env: TypeEnv, expr: BinExpr): TypeTag {
     typecheckLogger.trace(`[synthBinExpr]`);
@@ -245,18 +260,39 @@ function synthRef(env: TypeEnv, ref: Ref): TypeTag {
 }
 
 /**
- * Key Precondition: If the join is well-typed, then the reference of the leftmost child of the join is already resolved. 
- * This is guaranteed by the structure of the Join construct in the grammar: 
+ * Key Precondition: If the Project is well-typed, then the reference of the leftmost child of the Project is already resolved. 
+ * This is guaranteed by the structure of the Project construct in the grammar: 
  * because the depth of the leftmost child will not exceed that of the right, the scoper/linker will visit the leftmost child first
  * (and so, if the leftmost child is a Ref that can be resolved by the default linker, the Ref's reference will have been resolved) 
  */
-function synthJoin(env: TypeEnv, term: Join): TypeTag {
-    typecheckLogger.debug(`Trying to synth left of join: ${term.left.$type}`);
+function synthProject(env: TypeEnv, term: Project): TypeTag {
+    typecheckLogger.debug(`Trying to synth left of Project: ${term.left.$type}`);
     const typeOfLeft = inferType(env, term.left);
-    typecheckLogger.debug(`left of join :: ${typeOfLeft.toString()}`);
+    typecheckLogger.debug(`left of Project :: ${typeOfLeft.toString()}`);
 
     const rightRefName = term.right.value.$refText;
     
+    // With the type of the left sibling, we can infer what the type of `left `s` right` is
+    if (isRecordTTag(typeOfLeft)) {
+        const recordTag = typeOfLeft;
+
+        const memberType = recordTag.contains(rightRefName as IDOrBackTickedID);
+        if (memberType) {
+            typecheckLogger.debug(`(matchingMember) ${rightRefName} :: ${memberType.toString()}`);
+
+            return memberType ?? new ErrorTypeTag(term, "a project should have worked");
+            // TODO: Add checking of the synth'd type if necessary
+        } else {
+            return new ErrorTypeTag(term, `${rightRefName} not found in ${recordTag.getRecordName()}`)
+        }
+    } else {
+        return new ErrorTypeTag(term.left, `The type of something to the left of a a project / field access operator should be a Record, and not a ${typeOfLeft.toString()}`)
+    }
+}
+
+/*
+Sep 3: The old Sig/Relations version (now currently just using Project without Join)
+--------------------------------------------------------------------------------------
     // With the type of the left sibling, we can infer what the type of `left `s` right` is
     if (isSigTTag(typeOfLeft)) {
         const sig = typeOfLeft.getSig();
@@ -269,15 +305,15 @@ function synthJoin(env: TypeEnv, term: Join): TypeTag {
 
             const joinedType = relationType.joinOnLeft(typeOfLeft);
             typecheckLogger.debug(`joinedType: ${joinedType}`);
-            return joinedType ?? new ErrorTypeTag(term, "join should have worked");
+            return joinedType ?? new ErrorTypeTag(term, "a project should have worked");
             // TODO: Add checking of the synth'd type if necessary
         } else {
             return new ErrorTypeTag(term, `Relatum ${rightRefName} not found in ${sig.name}`)
         }
     } else {
-        return new ErrorTypeTag(term.left, `The type of something to the left of a join / field access operator should be a Concept, and not a ${typeOfLeft.toString()}`)
+        return new ErrorTypeTag(term.left, `The type of something to the left of a a project / field access operator should be a Record, and not a ${typeOfLeft.toString()}`)
     }
-}
+*/
 
 export function synthNewNode(env: TypeEnv, term: AstNode): TypeTag {
     typecheckLogger.trace(`--- [synthNewNode] -- term: ${term.$type}`);
@@ -290,7 +326,7 @@ export function synthNewNode(env: TypeEnv, term: AstNode): TypeTag {
     if (term.$type === "Ref") {
         typeTag = synthRef(env, term as Ref);
     } else if (isProjectExpr(term)) {
-        typeTag = synthJoin(env, term as Join);
+        typeTag = synthProject(env, term as Project);
 
     // Constructs whose types can be easily read off the term
     } else if (term.$type == "StringLiteral") {
@@ -299,6 +335,10 @@ export function synthNewNode(env: TypeEnv, term: AstNode): TypeTag {
         typeTag = new BooleanTTag(term as BooleanLiteral);
     } else if (term.$type == "IntegerLiteral") {
         typeTag = new IntegerTTag(term as IntegerLiteral);
+
+    } else if (term.$type == "VarDeclStmt") {
+        const varTerm = term as VarDeclStmt;
+        typeTag = varTerm.varType ? inferType(env, varTerm.varType) : inferType(env, varTerm.value);
     } else if (term.$type == "VarBinding") {
         const varTerm = term as VarBinding;
         typeTag = varTerm.varType ? inferType(env, varTerm.varType) : inferType(env, varTerm.value);
@@ -326,7 +366,11 @@ export function synthNewNode(env: TypeEnv, term: AstNode): TypeTag {
         typeTag = synthTypeAnnot(env, term as CustomTypeDef);
     } else if (term.$type === "BuiltinType") {
         typeTag = synthTypeAnnot(env, term as BuiltinType);
-        
+    } else if (isRecordDecl(term)) {
+        typeTag = synthRecord(env, term as RecordDecl);
+    } else if (isRowType(term)) {
+        const fieldType = inferType(env, term.value);
+        typeTag = new RowTypeTTag(term, fieldType);
     } else if (isSigDecl(term)) {
         typeTag = new SigTTag(term);
     } else if (isRelation(term)) {
@@ -460,19 +504,19 @@ const check = (env: TypeEnv, term: AstNode, type: TypeTag): TypeTag =>
 
 const isBoolExpr = (op: AstNode) => isComparisonOp(op) || (BOOL_OPERATORS.includes(op.$type));
 
+type SigOrRecordDecl = SigDecl | RecordDecl;
 
-/** Get Sig ancestors via DFS */
-export function getSigAncestors(sig: SigDecl): SigDecl[] {
-    const seen = new Set<SigDecl>();
-    const toVisit: SigDecl[] = [sig];
+function getAncestors(sigOrRecord: SigOrRecordDecl): SigOrRecordDecl[] {
+    const seen = new Set<SigOrRecordDecl>();
+    const toVisit: SigOrRecordDecl[] = [sigOrRecord];
 
     while (toVisit.length > 0) {
-        let next: SigDecl | undefined = toVisit.pop();
+        let next: SigOrRecordDecl | undefined = toVisit.pop();
         if (!next) break; // TODO: temp hack cos TS can't narrow based on length out of box
 
         if (!seen.has(next)) {
             seen.add(next);
-            next.parents.forEach((parent: Reference<SigDecl>) => { 
+            next.parents.forEach((parent: Reference<SigOrRecordDecl>) => { 
                 if (parent.ref) toVisit.push(parent.ref) 
             });
         }
@@ -480,10 +524,38 @@ export function getSigAncestors(sig: SigDecl): SigDecl[] {
 
     // Sets preserve insertion order
     const seenArr = Array.from(seen);
-    typecheckLogger.silly('seenArr:', seenArr.map(sig => sig.name));
+    typecheckLogger.silly('seenArr:', seenArr.map(sigOrRecord => sigOrRecord.name));
 
     return seenArr;
+
 }
+
+export const getSigAncestors = (sig: SigDecl) => getAncestors(sig) as SigDecl[];
+export const getRecordAncestors = (record: RecordDecl) => getAncestors(record) as RecordDecl[];
+
+// /** Get Sig ancestors via DFS */
+// export function getSigAncestors(sig: SigDecl): SigDecl[] {
+//     const seen = new Set<SigDecl>();
+//     const toVisit: SigDecl[] = [sig];
+
+//     while (toVisit.length > 0) {
+//         let next: SigDecl | undefined = toVisit.pop();
+//         if (!next) break; // TODO: temp hack cos TS can't narrow based on length out of box
+
+//         if (!seen.has(next)) {
+//             seen.add(next);
+//             next.parents.forEach((parent: Reference<SigDecl>) => { 
+//                 if (parent.ref) toVisit.push(parent.ref) 
+//             });
+//         }
+//     }
+
+//     // Sets preserve insertion order
+//     const seenArr = Array.from(seen);
+//     typecheckLogger.silly('seenArr:', seenArr.map(sig => sig.name));
+
+//     return seenArr;
+// }
 
 
 /*============= Error ================================ */

--- a/lam4-frontend/src/language/type-system/type-tags.ts
+++ b/lam4-frontend/src/language/type-system/type-tags.ts
@@ -396,6 +396,10 @@ export class RecordTTag implements TypeTag {
         return this.record;
     }
 
+    getRecordName(): string {
+        return this.record.name;
+    }
+
     contains(fieldname: IDOrBackTickedID): TypeTag | undefined {
         return this.rowTypes.get(fieldname);
     }
@@ -428,23 +432,24 @@ type RowTypePair = {
 export class RowTypeTTag implements TypeTag {
     readonly tag = "RowType";
     private readonly node: RowType;
-    private readonly rowType: RowTypePair;
+    private readonly rowTypePair: RowTypePair;
 
-    constructor(node: RowType, relatumType: TypeTag) {
-        this.rowType = {name: node.name,
-                        rowType: relatumType
+    constructor(node: RowType, fieldType: TypeTag) {
+        this.rowTypePair = {name: node.name,
+                        rowType: fieldType
         }
         this.node = node;
     }
     toString() {
-        return `${this.rowType.name}: ${this.rowType}`;
+        return this.rowTypePair.rowType.toString();
+        // `${this.rowTypePair.name}: ${this.rowTypePair.rowType.toString()}`;
     }
     getNode(): RowType {
         return this.node;
     }
     
     getRowType() {
-        return this.rowType;
+        return this.rowTypePair;
     }
 
     sameTypeAs(other: TypeTag): boolean {
@@ -476,7 +481,7 @@ export class SigTTag implements TypeTag {
 
     // TODO: Placeholder implementation; more thought required here -- depends on desired semantics!
     sameTypeAs(other: TypeTag): boolean {
-        return isSigTTag(other);
+        return this.sameSigAs(other);
     }
     // TODO: the subtyping judgment will be interesting
 }
@@ -499,7 +504,7 @@ export class RelationTTag implements TypeTag {
         this.relationType = [parentSigType, relatumType];
     }
     toString() {
-        return `${this.tag}: ${this.relationType}`;
+        return `${this.tag}: ${this.relationType.toString()}`;
     }
     getRelationNode(): Relation {
         return this.relationNode;


### PR DESCRIPTION
- Add basic support for records in type checker / adapt the old Sig/Join stuff to Record/Project (but keep basic support for SigDecl)
- Add `then` separator for sequential composition of actions