### PR TITLE
Add record decls to common syntax; implement parser for that and record exprs and projection and some other misc decls in backend parser

### DIFF
--- a/lam4-backend/src/Lam4/Expr/AbstractSyntax.hs
+++ b/lam4-backend/src/Lam4/Expr/AbstractSyntax.hs
@@ -6,10 +6,10 @@ import           Base.Grisette
 import           Lam4.Expr.Name (Name (..))
 import           Lam4.Expr.CommonSyntax
 
-newtype Decl = MyDecl (DeclF Expr)
+newtype Decl = MyDecl (DeclF Expr TypeDecl)
   deriving newtype (Eq, Show)
   deriving Generic
-  deriving (Mergeable, ExtractSym, EvalSym) via (Default (DeclF Expr))
+  deriving (Mergeable, ExtractSym, EvalSym) via (Default (DeclF Expr TypeDecl))
 
 data Expr
   = Var        Name

--- a/lam4-backend/src/Lam4/Expr/CommonSyntax.hs
+++ b/lam4-backend/src/Lam4/Expr/CommonSyntax.hs
@@ -2,14 +2,23 @@ module Lam4.Expr.CommonSyntax where
 
 import           Base
 import           Base.Grisette
-import           Lam4.Expr.Name (Name (..))
+import           Lam4.Expr.Name   (Name (..))
 
+type RecordLabel = Text
 
 -- | Basically a 'Binding'
-data DeclF a =
-    NonRec      Name a
-  | Rec         Name a
+data DeclF expr typedecl =
+    NonRec      Name expr
+  | Rec         Name expr
+  | TypeDecl    Name typedecl
   deriving stock (Show, Eq, Ord, Generic)
+
+-- TODO: Think about stuffing other metadata here too?
+data TypeDecl = RecordDecl [RowTypeDecl] [Name] (Maybe Text) -- ^ Labels Parents Description
+  deriving stock (Eq, Show, Ord, Generic)
+  deriving (Mergeable, ExtractSym, EvalSym) via (Default TypeDecl)
+
+type RowTypeDecl = (Name, TypeExpr)
 
 
 type Row a = [(Name, a)]
@@ -48,12 +57,12 @@ data BinOp
    deriving stock (Eq, Show, Ord, Generic)
   deriving (Mergeable, ExtractSym, EvalSym) via (Default BinOp)
 
-data Relatum
+data TypeExpr
   = CustomType  Name
-  | BuiltinType BuiltinTypeForRelation
+  | BuiltinType BuiltinType
   deriving stock (Eq, Show, Ord, Generic)
-  deriving (Mergeable, ExtractSym, EvalSym) via (Default Relatum)
+  deriving (Mergeable, ExtractSym, EvalSym) via (Default TypeExpr)
 
-data BuiltinTypeForRelation = BuiltinTypeString | BuiltinTypeInteger | BuiltinTypeBoolean
+data BuiltinType = BuiltinTypeString | BuiltinTypeInteger | BuiltinTypeBoolean
   deriving stock (Eq, Show, Ord, Generic)
-  deriving (Mergeable, ExtractSym, EvalSym) via (Default BuiltinTypeForRelation)
+  deriving (Mergeable, ExtractSym, EvalSym) via (Default BuiltinType)

--- a/lam4-backend/src/Lam4/Expr/Parser.hs
+++ b/lam4-backend/src/Lam4/Expr/Parser.hs
@@ -114,10 +114,13 @@ parseDecls = traverse parseDecl
 
 parseDecl :: A.Object -> Parser Decl
 parseDecl obj = do
-  expr <- parseExpr obj
   exprType <- obj .: "$type"
-  name <- getName obj
-  pure $ mkDecl exprType name expr
+  case exprType of
+    "VarDeclStmt" -> parseVarDecl obj
+    _ ->  do
+      expr <- parseExpr obj
+      name <- getName obj
+      pure $ mkDecl exprType name expr
 
 {----------------------
     parseExpr

--- a/lam4-backend/src/Lam4/Expr/Parser.hs
+++ b/lam4-backend/src/Lam4/Expr/Parser.hs
@@ -19,6 +19,14 @@ In short: the expression conforms, not just to the Lam4 grammar, but also to its
 The parsing/translation in Parser.hs preserves well-scopedness etc
   because the translation maps constructs in the Langium grammar to concrete syntax in a 1-to-1 way.
   The NamedElements are basically just relabelled with unique integers.
+
+
+  ----------
+    TODOs
+  ----------
+
+  Style / code clarity:
+  * Right now I'm using a mix of different idioms for interacting with JSON objects. I should standardize this when time permits
 -}
 
 module Lam4.Expr.Parser (
@@ -123,7 +131,8 @@ parseProgram program = do
   setEnv (zip nodePaths [1 .. ])
   parseDecls elementObjects
 
-{- | Note: typeOfNode here refers to the @$type@; i.e., the type of an @AstNode@ from the Langium parser -}
+{-| Constructor for @Decl@s. 
+Note: typeOfNode here refers to the @$type@; i.e., the type of an @AstNode@ from the Langium parser -}
 mkDecl :: Text -> Name -> Expr -> Decl
 mkDecl typeOfNode name expr =
   if has (contains typeOfNode) recursiveTypes
@@ -152,7 +161,6 @@ parseExpr node = do
   (node .: "$type" :: Parser Text) >>= \case
     "Ref"            -> parseRefToVar            (coerce node)
 
-    "SigDecl"        -> parseSigE           node
 
     -- literals
     "IntLit" -> parseIntegerLiteral node
@@ -172,7 +180,10 @@ parseExpr node = do
     "UnaryExpr"      -> parseUnaryExpr      node
     "IfThenElseExpr" -> parseIfThenElse     node
 
-    -- Note: Join is in the process of being disabled / deprecated
+    {-  Join is currently disabled / deprecated, but may return if we want to do certain kinds of symbolic analysis
+      May want to remove Sigs as well. Not sure right now, and keeping it around for the time being makes the syntax for certain things a bit nicer
+    -}
+    "SigDecl"        -> parseSigE           node
     "RecordExpr"     -> parseRecordExpr     node
     "Project"        -> parseProject        node
 

--- a/lam4-backend/src/Lam4/Expr/Parser.hs
+++ b/lam4-backend/src/Lam4/Expr/Parser.hs
@@ -149,7 +149,7 @@ parseExpr node = do
     "IfThenElseExpr" -> parseIfThenElse     node
 
     -- Note: Join is in the process of being disabled / deprecated
-    "Join"           -> parseJoin           node
+    "Project"        -> parseProject        node
 
     typestr          -> throwError $ T.unpack typestr <> " not yet implemented"
 
@@ -201,9 +201,9 @@ parseSigE sigNode = do
   pure $ Sig parents relations
 
 
-{-----------------------------------
-    BinExpr, UnaryExpr, IfThenElse
-------------------------------------}
+{-------------------------------------------
+    BinExpr, Project, UnaryExpr, IfThenElse
+---------------------------------------------}
 
 parseBinExpr :: A.Object -> Parser Expr
 parseBinExpr node = do
@@ -212,11 +212,11 @@ parseBinExpr node = do
   right <- parseExpr  =<< node .: "right"
   pure $ BinExpr op left right
 
-parseJoin ::  A.Object -> Parser Expr
-parseJoin node = do
+parseProject ::  A.Object -> Parser Expr
+parseProject node = do
   left <- parseExpr =<< node .: "left"
-  right <- parseExpr =<< node .: "right"
-  pure $ Join left right
+  fieldname <- relabelBareRef $ coerce $ node `objAtKey` "right" 
+  pure $ Project left fieldname
 
 parseBinOp :: A.Object -> Parser BinOp
 parseBinOp opObj = do

--- a/lam4-backend/src/Lam4/Parser/Type.hs
+++ b/lam4-backend/src/Lam4/Parser/Type.hs
@@ -10,12 +10,15 @@ module Lam4.Parser.Type (
 
   -- * RefPath, Env
   RefPath,
-  Env
+  Env,
+  -- * RecordLabel related
+  RecordLabel,
+  RecordLabelEnv,
 ) where
 
 import           Base
 import qualified Base.Aeson             as A
-import           Lam4.Expr.Name         (Unique)
+import           Lam4.Expr.Name         (Unique, Name(..))
 
 import           Control.Monad.Base
 import           Control.Monad.Except   ()
@@ -37,17 +40,24 @@ __Examples:__
 -}
 type RefPath = Text
 
+type RecordLabel = Text
+
 -- | Environment for Parser: map from RefPaths to Uniques/Ints
 type Env = Map RefPath Unique
+
+{- | See relevant discussion in Parser.hs -}
+type RecordLabelEnv = Map RecordLabel Name
 
 {----------------------------
     ParserState, Parser
 -----------------------------}
 
--- | does NOT include the input object / value
+-- | State for our Parser monad. Does NOT include the input object / value
 data ParserState = MkParserState
-  { refPathEnv :: !Env
-  , maxUnique  :: !Unique -- ^ for making fresh int vars
+  { refPathEnv     :: !Env
+  , maxUnique      :: !Unique 
+    -- ^ maxUnique in @refPathEnv@. TODO: may not need this; we'll see
+  , recordLabelEnv :: !RecordLabelEnv
   }
   deriving stock (Show, Generic)
 

--- a/lam4-backend/src/Lam4/Parser/Type.hs
+++ b/lam4-backend/src/Lam4/Parser/Type.hs
@@ -19,6 +19,7 @@ module Lam4.Parser.Type (
 import           Base
 import qualified Base.Aeson             as A
 import           Lam4.Expr.Name         (Unique, Name(..))
+import           Lam4.Expr.CommonSyntax (RecordLabel)
 
 import           Control.Monad.Base
 import           Control.Monad.Except   ()
@@ -39,8 +40,6 @@ __Examples:__
 @
 -}
 type RefPath = Text
-
-type RecordLabel = Text
 
 -- | Environment for Parser: map from RefPaths to Uniques/Ints
 type Env = Map RefPath Unique

--- a/lam4-frontend/src/language/lam4.langium
+++ b/lam4-frontend/src/language/lam4.langium
@@ -326,6 +326,7 @@ FunctionApplication:
 ;
 
 // sugar for func app, when doing *concrete* evaluation
+// TODO: I'm not sure that it's worth having two different styles of syntax for InfixPredicateApplication, sigh
 InfixPredicateApplication: 
    ( args+=[NamedElement:ID] 'IS'? predicate=Expr ) // TODO: not sure actually that we even want to have `IS` as an option -- might be better style to have that in the name of the predicate itself
    | ( '(' args+=Expr (',' args+=Expr)* ')' ('IS' | 'ARE')? predicate=Expr )

--- a/lam4-frontend/src/language/type-system/type-tags.ts
+++ b/lam4-frontend/src/language/type-system/type-tags.ts
@@ -388,8 +388,9 @@ export class RecordTTag implements TypeTag {
 
         this.rowTypes = new Map(rowTypes.map(row => [row.name, row.rowType]));;
     }
+    
     toString(): string {
-        return `Record ${this.record.name}`;
+        return `Structure '${this.record.name}'`;
     }
 
     getRecord(): RecordDecl {


### PR DESCRIPTION
The biggest class of things right now that is in the Langium grammar but not yet supported in the backend parser is the normative stuff.

The Haskell backend parser has *not* been tested thoroughly -- that's a big short-term TODO as well