### PR TITLE
Improve pred decl app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ cabal.project.local~
 node_modules
 
 /generated/
+lam4-frontend/generated/

--- a/examples/PostfixPredicateApplication.l4
+++ b/examples/PostfixPredicateApplication.l4
@@ -1,0 +1,20 @@
+// Demonstrates postfix predicate application
+
+/- 
+About: "A Person is pretty much what you would expect"
+-/
+STRUCTURE Person { some_number IS_A Integer }
+
+Integer => Integer
+f(x) = 2
+
+DECIDE `some fact`
+IF True
+
+GIVEN (person: Person)
+DECIDE `is eligible`
+IF `some fact` HOLDS?
+AND f(1) + person`s` some_number EQUALS 2
+
+DEFINE x: Person = {| some_number = 1 |}
+@REPORT x `is eligible`

--- a/examples/infix_pred_app.l4
+++ b/examples/infix_pred_app.l4
@@ -6,23 +6,21 @@ About: "A Person is pretty much what you would expect"
 STRUCTURE Person {}
 
 GIVEN (x: Person 
-       y: Person 
-       z: Person)
-DECIDE special
+       y: Person)
+DECIDE `has helped`
 IF True
 
 GIVEN (
     person1: Person
     person2: Person
-    person3: Person
 )
 DECIDE eligible 
-IF (person1, person2, person3) ARE special
+IF person1 `has helped` person2
 
 GIVEN (person: Person)
-DECIDE fun
+DECIDE `is fun`
 IF True
 
 GIVEN (x: Person)
 DECIDE bleh
-IF x IS fun
+IF x `is fun`

--- a/examples/not.l4
+++ b/examples/not.l4
@@ -11,7 +11,7 @@ IF NOT x`s` publications < 2
 
 GIVEN (x IS_A Applicant)
 DECIDE `happy`
-IF x IS `is eligible for grant` AND NOT NOT x IS `is eligible for grant` // deliberately overly complicated example
+IF x `is eligible for grant` AND NOT NOT x `is eligible for grant` // deliberately overly complicated example
 
 DEFINE x = {| publications = 3 |}
 @REPORT x `is eligible for grant`

--- a/examples/simple_join_or_record_field_deref.l4
+++ b/examples/simple_join_or_record_field_deref.l4
@@ -8,9 +8,9 @@ Applicant => Integer
 numberOfPublications(applicant) = applicant`s` publications
 
 GIVEN (x IS_A Applicant)
-DECIDE `eligible for grant`
+DECIDE `is eligible for grant`
 IF x`s` publications > 10
 
 GIVEN (x IS_A Applicant)
 DECIDE `happy`
-IF x IS `eligible for grant`
+IF x `is eligible for grant`

--- a/lam4-backend/lam4-backend.cabal
+++ b/lam4-backend/lam4-backend.cabal
@@ -60,7 +60,8 @@ library
         base,
         containers,
         foldable1-classes-compat,
-        lens,
+        lens, 
+        -- just for Control.Lens.Plated
         optics,
         mtl,
         transformers-base,

--- a/lam4-backend/src/Lam4/Expr/CommonSyntax.hs
+++ b/lam4-backend/src/Lam4/Expr/CommonSyntax.hs
@@ -84,8 +84,12 @@ data BinOp
   deriving (Mergeable, ExtractSym, EvalSym) via (Default BinOp)
 
 data TypeExpr
-  = CustomType  Name
-  | BuiltinType BuiltinType
+  = TyCustom  Name
+    -- ^ aka "CustomType" from the Langium grammar
+  | TyBuiltin TyBuiltin
+    -- ^ aka "BuiltinType" from the Langium grammar
+  | TyFun     TypeExpr TypeExpr
+    -- ^ functions
   deriving stock (Eq, Show, Ord, Generic)
   deriving (Mergeable, ExtractSym, EvalSym) via (Default TypeExpr)
 
@@ -96,23 +100,23 @@ data RowTypeDecl = MkRowTypeDecl { name      :: Name
   deriving stock (Eq, Show, Ord, Generic)
   deriving (Mergeable, ExtractSym, EvalSym) via (Default RowTypeDecl)
 
-data BuiltinType = BuiltinTypeString | BuiltinTypeInteger | BuiltinTypeBoolean
+data TyBuiltin = BuiltinTypeString | BuiltinTypeInteger | BuiltinTypeBoolean
   deriving stock (Eq, Show, Ord, Generic)
-  deriving (Mergeable, ExtractSym, EvalSym) via (Default BuiltinType)
+  deriving (Mergeable, ExtractSym, EvalSym) via (Default TyBuiltin)
 
 -- TODO: Think about stuffing other metadata here too?
-data TypeDecl = RecordDecl [RowTypeDecl] [Name] RecordDeclMetadata -- ^ Labels Parents Description RecordDeclMetadata
+data DataDecl = RecordDecl [RowTypeDecl] [Name] RecordDeclMetadata -- ^ Labels Parents Description RecordDeclMetadata
   deriving stock (Eq, Show, Ord, Generic)
-  deriving (Mergeable, ExtractSym, EvalSym) via (Default TypeDecl)
+  deriving (Mergeable, ExtractSym, EvalSym) via (Default DataDecl)
 
 -- | Basically a 'Binding'
 data DeclF expr =
     NonRec      Name expr
   | Rec         Name expr
   | Eval        expr
-  | TypeDecl    Name TypeDecl
+  | DataDecl    Name DataDecl
   deriving stock (Show, Eq, Ord, Generic)
 
 makePrisms ''TypeExpr
-makePrisms ''TypeDecl
+makePrisms ''DataDecl
 makePrisms ''DeclF

--- a/lam4-backend/src/Lam4/Expr/ConcreteSyntax.hs
+++ b/lam4-backend/src/Lam4/Expr/ConcreteSyntax.hs
@@ -4,10 +4,7 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
-{-
-TODO:
-* Add Builtin list operations
--}
+
 module Lam4.Expr.ConcreteSyntax
   (
   -- re-exports from common syntax

--- a/lam4-backend/src/Lam4/Expr/ConcreteSyntax.hs
+++ b/lam4-backend/src/Lam4/Expr/ConcreteSyntax.hs
@@ -9,7 +9,7 @@ module Lam4.Expr.ConcreteSyntax
   (
   -- re-exports from common syntax
     TypeExpr(..)
-  , BuiltinType(..)
+  , TyBuiltin(..)
   , RowTypeDecl(..)
   -- * Decl and convenience constructors
   , Decl
@@ -53,7 +53,7 @@ mkSingletonStatementDecl :: Name -> Statement -> Decl
 mkSingletonStatementDecl name statement = mkStatementBlockDecl name $ singleton statement
 
 mkRecordDecl :: Name -> [RowTypeDecl] -> [Name] -> RecordDeclMetadata -> Decl
-mkRecordDecl recordName rowTypeDecls parents recordDeclMetadata = TypeDecl recordName (RecordDecl rowTypeDecls parents recordDeclMetadata)
+mkRecordDecl recordName rowTypeDecls parents recordDeclMetadata = DataDecl recordName (RecordDecl rowTypeDecls parents recordDeclMetadata)
 
 
 {-

--- a/lam4-backend/src/Lam4/Expr/Parser.hs
+++ b/lam4-backend/src/Lam4/Expr/Parser.hs
@@ -254,7 +254,7 @@ parseExpr node = do
     TypeExpr and Relation related
 -----------------------------------}
 
-parseBuiltinType :: Text -> Parser BuiltinType
+parseBuiltinType :: Text -> Parser TyBuiltin
 parseBuiltinType = \case
     "Integer" -> pure BuiltinTypeInteger
     "String"  -> pure BuiltinTypeString
@@ -266,10 +266,10 @@ parseTypeExpr node = do
   (node .: "$type" :: Parser Text) >>= \case
     "CustomTypeDef" -> do
       name <- relabelBareRef $ coerce $ node `objAtKey` "annot"
-      pure $ CustomType name
+      pure $ TyCustom name
     "BuiltinType"   -> do
       builtinType <- parseBuiltinType =<< (node .: "annot" :: Parser Text)
-      pure $ BuiltinType builtinType
+      pure $ TyBuiltin builtinType
     other           -> throwError $ "unrecognized type"  <> T.unpack other
 
 parseRelation :: Name -> A.Object -> Parser Expr

--- a/lam4-backend/src/Lam4/Expr/Parser.hs
+++ b/lam4-backend/src/Lam4/Expr/Parser.hs
@@ -586,10 +586,6 @@ parseBooleanLiteral literalNode = do
       Just "False" -> pure . Lit $ BoolLit False
       _ -> throwError $ "Failed to parse boolean literal. Node: " <> ppShow literalNode
 
--- parseLiteral :: FromJSON t => (t -> Lit) -> A.Object -> Parser Expr
--- parseLiteral literalExprCtor literalNode = do
---     literalVal <- literalNode .: "value"
---     return $ Lit $ literalExprCtor literalVal
 
 {----------------------
     Utils

--- a/lam4-backend/src/Lam4/Expr/Parser.hs
+++ b/lam4-backend/src/Lam4/Expr/Parser.hs
@@ -98,7 +98,21 @@ relabelBareRef = relabelRefHelper getRefPath getRefText
     getRefPath node = node ^? ix "$ref" % _String
     getRefText node = node ^? ix "$refText" % _String
 
-{- | Relabel an object that is a ('wrapped') `Ref` to a `Name` -}
+{- | Relabel an object that is a ('wrapped') `Ref` to a `Name`.
+
+An example of a 'wrapped' Ref:
+  @
+  {
+    "$type": "Ref",
+    "value": {
+        "$ref": "#/elements@2",
+        "$refText": "some fact"
+    }
+  }
+  @
+
+A wrapped Ref differs from a bare/unwrapped one in that the underlying bare ref is tucked into the @value@ field.
+-}
 relabelRef :: WrappedRef -> Parser Name
 relabelRef wrappedRef = relabelRefHelper getRef getRefText (coerce wrappedRef)
   where
@@ -114,7 +128,7 @@ relabelRefHelper getRefPath getRefText (MkRef node) = do
     (Just refPath', Just refText') -> do
       refUnique <- refPathToUnique refPath'
       pure $ MkName refText' refUnique
-    _ -> throwError $ ppShow node <> " impossible"
+    _ -> throwError $ "[relabelRefHelper]\n" <> ppShow node <> " impossible"
 
 {----------------------
     Program
@@ -213,7 +227,8 @@ parseExpr node = do
     "PredicateDecl"  -> parsePredicateE     node
 
     "FunctionApplication"       -> parseFunApp node
-    "InfixPredicateApplication" -> parsePredicateApp node
+    "InfixPredicateApplication" -> parseInfixPredicateApp node
+    "PostfixPredicateApplication" -> parsePostfixPredicateApp node
 
     "BinExpr"        -> parseBinExpr        node
 
@@ -506,11 +521,44 @@ parsePredicateAppArg arg =
   then parseExpr arg
   else parseBareRefToVar (coerce arg)
 
-parsePredicateApp ::  A.Object -> Parser Expr
-parsePredicateApp predApp = do
+{- | Sep 18 2024: I'm desugaring this to PredApp, instead of adding a separate InfixPredApp construct,
+because having a more faithful concrete syntax is not the priority right now. 
+But will add that when time permits, since it is useful for things like rendering, synchronization, automated refactoring.
+-}
+parseInfixPredicateApp ::  A.Object -> Parser Expr
+parseInfixPredicateApp predApp = do
     predicate <- parseBareRefToVar =<< predApp .: "predicate"
+    left  <- parseExpr  =<< predApp .: "left"
+    -- the @right@ may not be present
+    right <- traverse parseExpr $ predApp ^? ix "right" % _Object
+    pure $ case right of
+      Just rightExpr -> 
+        let args = [left, rightExpr]
+        in PredApp predicate args
+      Nothing ->
+        PredApp predicate [left]
+
+{- | Example of a PostfixPredicateApplication node (Sep 18 2024):
+
+    @
+    {
+        "$type": "PostfixPredicateApplication",
+        "predicate": {
+            "$type": "Ref",
+            "value": {
+                "$ref": "#/elements@2",
+                "$refText": "some fact"
+            }
+        }
+    }
+    @
+-}
+parsePostfixPredicateApp ::  A.Object -> Parser Expr
+parsePostfixPredicateApp predApp = do
+    predicate <- parseRefToVar =<< predApp .: "predicate"
     args      <- traverse parsePredicateAppArg (predApp `getObjectsAtField` "args")
     pure $ PredApp predicate args
+
 
 parseFunApp :: A.Object -> Parser Expr
 parseFunApp funApp = do

--- a/lam4-backend/src/Lam4/Expr/SymEvalAST.hs
+++ b/lam4-backend/src/Lam4/Expr/SymEvalAST.hs
@@ -11,7 +11,7 @@ import           Base.Grisette
 
 import           Lam4.Expr.Name (Name (..))
 import           Lam4.Expr.CommonSyntax
-import           Lam4.Expr.ConcreteSyntax qualified as CST (Lit (..), Decl)
+-- import           Lam4.Expr.ConcreteSyntax qualified as CST (Lit (..), Decl)
 
 {-================================================
           For symbolic eval

--- a/lam4-backend/src/Lam4/Expr/ToConcreteEvalAST.hs
+++ b/lam4-backend/src/Lam4/Expr/ToConcreteEvalAST.hs
@@ -27,7 +27,7 @@ toConEvalDecl = \case
   CST.NonRec name expr       -> AST.NonRec name (toConEvalExpr expr)
   CST.Rec name expr          -> AST.Rec name (toConEvalExpr expr)
   CST.Eval expr              -> AST.Eval (toConEvalExpr expr)
-  CST.TypeDecl name typedecl -> AST.TypeDecl name typedecl
+  CST.DataDecl name typedecl -> AST.DataDecl name typedecl
 
 toConEvalExpr :: CST.Expr -> AST.ConEvalExpr
 toConEvalExpr expression =

--- a/lam4-backend/src/Lam4/Expr/ToSimala.hs
+++ b/lam4-backend/src/Lam4/Expr/ToSimala.hs
@@ -75,7 +75,7 @@ compileBinOp = \case
 
 compile  :: [AST.ConEvalDecl] -> SimalaProgram
 compile decls = decls
-  & filter (\case { TypeDecl{} -> False; _ -> True })
+  & filter (\case { DataDecl{} -> False; _ -> True })
   & map compileDecl
 
 compileDecl :: AST.ConEvalDecl -> SimalaDecl
@@ -100,7 +100,7 @@ compileDecl = \case
   Rec name expr    -> SM.Rec defaultTransparency (lam4ToSimalaName name) (compileExpr expr)
   Eval expr        -> SM.Eval (compileExpr expr)
   -- TODO: Improve the error handling later
-  TypeDecl{}       -> error "[ToSimala] Type declarations not supported in Simala and should already have been pre-filtered out, prior to this phase"
+  DataDecl{}       -> error "[ToSimala] Type declarations not supported in Simala and should already have been pre-filtered out, prior to this phase"
 
 
 compileExpr :: AST.ConEvalExpr -> SM.Expr

--- a/lam4-cli/app/Main.hs
+++ b/lam4-cli/app/Main.hs
@@ -15,7 +15,7 @@ import           Cradle
 import qualified Lam4.Expr.ConcreteSyntax      as CST (Decl)
 import           Lam4.Expr.Parser              (parseProgramByteStr)
 import           Lam4.Expr.ToConcreteEvalAST   (cstProgramToConEvalProgram)
-import           Lam4.Expr.ToSimala            (SimalaProgram)
+import           Lam4.Expr.ToSimala            ()
 import qualified Lam4.Expr.ToSimala            as ToSimala
 import           Lam4.Parser.Monad             (evalParserFromScratch)
 import           Options.Applicative           as Options

--- a/lam4-frontend/src/language/lam4.langium
+++ b/lam4-frontend/src/language/lam4.langium
@@ -333,12 +333,27 @@ Join infers Expr:
 
 
 InfixPredicateApplication infers Expr:
-    PostfixPredicateApplication
-    ({infer InfixPredicateApplication.left = current}
-     predicate=[PredicateDecl:IDOrBackTickedID]
-     right=PostfixPredicateApplication?
+    InfixActionApplication
+    (
+        {infer InfixPredicateApplication.left = current}
+        predicate=[PredicateDecl:IDOrBackTickedID]
+        right=InfixActionApplication?
     )*
 ;
+
+InfixActionApplication infers Expr:
+    PostfixPredicateApplication
+    (
+        {infer InfixActionApplication.left = current}
+        ("DOES" | "DO") 
+        // ("DOES" | "DO") is a short term hack to avoid clashing with InfixPredicateApplication.
+        // TODO: Might want to just overload the surface syntax for action/predicate application and use type annotations / inference to distinguish them?
+        // Also, may want to add an infix fun app and then use Langium actions to desugar this to an infix fun app?
+        action=[ActionDecl:IDOrBackTickedID]
+        right=PostfixPredicateApplication?
+    )*
+;
+
 
 fragment ExprArgs: 
     (args+=Expr)? (',' args+=Expr)*
@@ -366,28 +381,6 @@ FunctionApplication:
     ExprArgsInParens)*
 ;
 
-// sugar for func app, when doing *concrete* evaluation
-// Also probably want to add syntactic sugar for stuff like X `pred` Y.
-// TODO: I'm not sure that it's worth having all these different styles of syntax for InfixPredicateApplication, sigh
-// InfixPredicateApplication: 
-//    ( args+=[NamedElement:IDOrBackTickedID] 'IS'? predicate=Expr
-//     ) 
-//     // TODO: not sure actually that we even want to have `IS` as an option -- might be better style to have that in the name of the predicate itself
-//    | ( ExprArgs ('IS' | 'ARE')? predicate=Expr )
-//    | (predicate=Expr 'HOLDS?') // for nullary predicates
-// ;
-
-
-
-// InfixActionApplication:
-//     ( (args+=[NamedElement:IDOrBackTickedID])
-//     | ( '(' args+=Expr (',' args+=Expr)* ')' ) 
-//     )
-//     ("DOES" | "DO") 
-//     // ("DOES" | "DO") is a short term hack to avoid clashing with InfixPredicateApplication. 
-//     // TODO: When time permits, probably want to just overload the surface syntax for action/predicate application and use type inference to distinguish them?
-//     action=[ActionDecl:IDOrBackTickedID]
-// ;
 
 // sugar for a predicate that checks if the referenced norm is violated
 NormIsInfringed:
@@ -406,9 +399,6 @@ AnonFunction:
 
 PrimitiveExpr infers Expr:
     '(' Expr ')' | AnonFunction 
-    // | InfixActionApplication 
-    // InFixActionApplication must be declared before InfixPredicateApplication
-    // | InfixPredicateApplication 
     | NormIsInfringed | Ref | UnaryExpr | IntegerLiteral | BooleanLiteral
     // Not sure if we want to allow for string literals as expressions
 ;

--- a/lam4-frontend/src/language/lam4.langium
+++ b/lam4-frontend/src/language/lam4.langium
@@ -311,25 +311,7 @@ Project infers Expr:
 /* ---------------------------------------------------
 Aug 24 2024: Join is currently disabled; 
 am porting what I currently have for Join to Project
--------------------------------------------------------
-TODO: Add a variant of this in the standard library for relational join in the other direction --- maybe use "`of`"
-
-(To be clear, the auto-linking/crossref for this won't work in the playground: https://github.com/eclipse-langium/langium/discussions/1502)
-
-The relationship between relational join and a more conventional member access operator:
-    Can think of dereferencing a field of an object as corresponding to a special case of relational join --- this is a common trick / idiom in the Alloy community
-*/
-// Join infers Expr:
-//     FunctionApplication ({infer Join.left=current} '`s`' right=Ref)*
-    // Right can't be [NamedElement:ID]
-    // because we want the scoper to visit `left` first,
-    // so that if `left`'s reference will be resolved via the default scoper/linker, if that's possible.
-    // This allows us to then use that resolved reference
-    // as a base case in figuring out the reference for `right`
-
-    // TODO: 's and `s don't work out of the box
-    // Can prob allow for "'s" by customizing the TokenBuilder
-// ;
+-------------------------------------------------------*/
 
 
 InfixPredicateApplication infers Expr:

--- a/lam4-frontend/src/language/lam4.langium
+++ b/lam4-frontend/src/language/lam4.langium
@@ -319,8 +319,8 @@ TODO: Add a variant of this in the standard library for relational join in the o
 The relationship between relational join and a more conventional member access operator:
     Can think of dereferencing a field of an object as corresponding to a special case of relational join --- this is a common trick / idiom in the Alloy community
 */
-Join infers Expr:
-    FunctionApplication ({infer Join.left=current} '`s`' right=Ref)*
+// Join infers Expr:
+//     FunctionApplication ({infer Join.left=current} '`s`' right=Ref)*
     // Right can't be [NamedElement:ID]
     // because we want the scoper to visit `left` first,
     // so that if `left`'s reference will be resolved via the default scoper/linker, if that's possible.
@@ -329,7 +329,7 @@ Join infers Expr:
 
     // TODO: 's and `s don't work out of the box
     // Can prob allow for "'s" by customizing the TokenBuilder
-;
+// ;
 
 
 InfixPredicateApplication infers Expr:

--- a/lam4-frontend/src/language/lam4.langium
+++ b/lam4-frontend/src/language/lam4.langium
@@ -300,7 +300,7 @@ Mult infers Expr:
 (To be clear, the auto-linking/crossref for this won't work in the playground: https://github.com/eclipse-langium/langium/discussions/1502)
 */
 Project infers Expr:
-    FunctionApplication ({infer Project.left=current} '`s`' right=Ref)*
+    InfixPredicateApplication ({infer Project.left=current} '`s`' right=Ref)*
     // Right can't be [NamedElement:ID]
     // because we want the scoper to visit `left` first,
     // so that if `left`'s reference will be resolved via the default scoper/linker, if that's possible.
@@ -331,11 +331,20 @@ Join infers Expr:
     // Can prob allow for "'s" by customizing the TokenBuilder
 ;
 
+
+InfixPredicateApplication infers Expr:
+    FunctionApplication
+    ({infer InfixPredicateApplication.left = current}
+     predicate=[PredicateDecl:IDOrBackTickedID]
+     right=FunctionApplication?
+    )*
+;
+
 fragment ExprArgs: 
     '(' (args+=Expr)? (',' args+=Expr)* ')'
 ;
 
-// with postfix predicate application as a special case of this, when doing *concrete* evaluation
+
 FunctionApplication:
     PrimitiveExpr
     ({infer FunctionApplication.func=current}
@@ -345,23 +354,25 @@ FunctionApplication:
 // sugar for func app, when doing *concrete* evaluation
 // Also probably want to add syntactic sugar for stuff like X `pred` Y.
 // TODO: I'm not sure that it's worth having all these different styles of syntax for InfixPredicateApplication, sigh
-InfixPredicateApplication: 
-   ( args+=[NamedElement:ID] 'IS'? predicate=[PredicateDecl:IDOrBackTickedID]
-    ) 
-    // TODO: not sure actually that we even want to have `IS` as an option -- might be better style to have that in the name of the predicate itself
-   | ( ExprArgs ('IS' | 'ARE')? predicate=[PredicateDecl:IDOrBackTickedID] )
-   | (predicate=[PredicateDecl:IDOrBackTickedID] 'HOLDS?') // for nullary predicates
-;
+// InfixPredicateApplication: 
+//    ( args+=[NamedElement:IDOrBackTickedID] 'IS'? predicate=Expr
+//     ) 
+//     // TODO: not sure actually that we even want to have `IS` as an option -- might be better style to have that in the name of the predicate itself
+//    | ( ExprArgs ('IS' | 'ARE')? predicate=Expr )
+//    | (predicate=Expr 'HOLDS?') // for nullary predicates
+// ;
 
-InfixActionApplication:
-    ( (args+=[NamedElement:IDOrBackTickedID])
-    | ( '(' args+=Expr (',' args+=Expr)* ')' ) 
-    )
-    ("DOES" | "DO") 
-    // ("DOES" | "DO") is a short term hack to avoid clashing with InfixPredicateApplication. 
-    // TODO: When time permits, probably want to just overload the surface syntax for action/predicate application and use type inference to distinguish them?
-    action=[ActionDecl:IDOrBackTickedID]
-;
+
+
+// InfixActionApplication:
+//     ( (args+=[NamedElement:IDOrBackTickedID])
+//     | ( '(' args+=Expr (',' args+=Expr)* ')' ) 
+//     )
+//     ("DOES" | "DO") 
+//     // ("DOES" | "DO") is a short term hack to avoid clashing with InfixPredicateApplication. 
+//     // TODO: When time permits, probably want to just overload the surface syntax for action/predicate application and use type inference to distinguish them?
+//     action=[ActionDecl:IDOrBackTickedID]
+// ;
 
 // sugar for a predicate that checks if the referenced norm is violated
 NormIsInfringed:
@@ -379,9 +390,11 @@ AnonFunction:
 
 
 PrimitiveExpr infers Expr:
-    '(' Expr ')' | AnonFunction | InfixActionApplication 
+    '(' Expr ')' | AnonFunction 
+    // | InfixActionApplication 
     // InFixActionApplication must be declared before InfixPredicateApplication
-    | InfixPredicateApplication | NormIsInfringed | Ref | UnaryExpr | IntegerLiteral | BooleanLiteral
+    // | InfixPredicateApplication 
+    | NormIsInfringed | Ref | UnaryExpr | IntegerLiteral | BooleanLiteral
     // Not sure if we want to allow for string literals as expressions
 ;
 

--- a/lam4-frontend/src/language/lam4.langium
+++ b/lam4-frontend/src/language/lam4.langium
@@ -333,22 +333,37 @@ Join infers Expr:
 
 
 InfixPredicateApplication infers Expr:
-    FunctionApplication
+    PostfixPredicateApplication
     ({infer InfixPredicateApplication.left = current}
      predicate=[PredicateDecl:IDOrBackTickedID]
-     right=FunctionApplication?
+     right=PostfixPredicateApplication?
     )*
 ;
 
 fragment ExprArgs: 
-    '(' (args+=Expr)? (',' args+=Expr)* ')'
+    (args+=Expr)? (',' args+=Expr)*
+;
+
+fragment ExprArgsInParens:
+    '(' ExprArgs ')'
+;
+
+
+PostfixPredicateApplication:
+    FunctionApplication
+    ({infer PostfixPredicateApplication.predicate=current}
+
+    ( ( ('IS_SATISFIED_BY' | 'HOLDS_OF') ExprArgsInParens )
+    | 'HOLDS?' )   
+    
+    )*
 ;
 
 
 FunctionApplication:
     PrimitiveExpr
     ({infer FunctionApplication.func=current}
-    ExprArgs)*
+    ExprArgsInParens)*
 ;
 
 // sugar for func app, when doing *concrete* evaluation


### PR DESCRIPTION
1. Refactor predicate and action application in the Langium grammar (streamlined some of the pred app; distinguish between postfix and infix pred app)
2. Update backend parser accordingly, though still desugaring to one PredApp construct
3. Add function type to backend concrete syntax
4. Update .gitignore to exclude generated files
5. Misc clean ups

@inariksit I haven't added infix pred app to the backend ConcreteSyntax (just desugaring it right now to PredApp) --- I'm deferring that for now because getting the web-based IDE up etc is higher priority
