### PR TITLE
Langium Grammar: Allow for an 'infix' predicate definition style. This is purely cosmetic / stylistic.

### DIFF
--- a/examples/infix_pred_app.l4
+++ b/examples/infix_pred_app.l4
@@ -5,17 +5,18 @@ About: "A Person is pretty much what you would expect"
 -/
 STRUCTURE Person {}
 
-GIVEN (x: Person 
-       y: Person)
-DECIDE `has helped`
+// 'infix' predicate definition. The use of the params past the `DECIDE` is purely cosmetic. 
+GIVEN (some_person: Person 
+       another_person: Person)
+DECIDE some_person `has helped` another_person
 IF True
 
-GIVEN (
-    person1: Person
-    person2: Person
+// Don't need to actually use the params if you don't want to.
+GIVEN (some_person: Person 
+       another_person: Person
 )
-DECIDE eligible 
-IF person1 `has helped` person2
+DECIDE `has met` 
+IF some_person `has helped` another_person
 
 GIVEN (person: Person)
 DECIDE `is fun`

--- a/lam4-frontend/src/language/lam4.langium
+++ b/lam4-frontend/src/language/lam4.langium
@@ -207,7 +207,7 @@ PredicateDecl:
     // WithSpecificMetadataBlock?
 
     GivenParamBlock?
-    'DECIDE' name=IDOrBackTickedID 
+    'DECIDE' left=[Param:ID]? name=IDOrBackTickedID right=[Param:ID]?
     // can think of 'name' as 'head'
     'IF' body=Expr 
     /* The 'IF' here is more like a 'IFF' or 'just in case', rather than a mere 'if',


### PR DESCRIPTION
<img width="864" alt="image" src="https://github.com/user-attachments/assets/a06b5ce8-f785-42de-b05b-442e01e26a45">

TODO: Add a validator to warn user if they miss one of the params, e.g.
```
GIVEN (some_person: Person 
       another_person: Person)
DECIDE some_person `has helped`
IF True
```
(This is purely stylistic, but could still be confusing to a reader; hence the need for a validator)