### PR TITLE
Langium Grammar: Allow param names to be backticked ID as well.

### DIFF
--- a/lam4-frontend/src/language/lam4.langium
+++ b/lam4-frontend/src/language/lam4.langium
@@ -161,7 +161,7 @@ fragment GivenParamBlock:
 ;
 
 Param:
-    name=ID;
+    name=IDOrBackTickedID;
 
 ParamTypePair:
     param=Param (':' | 'IS_A') type=TypeAnnot
@@ -207,7 +207,7 @@ PredicateDecl:
     // WithSpecificMetadataBlock?
 
     GivenParamBlock?
-    'DECIDE' left=[Param:ID]? name=IDOrBackTickedID right=[Param:ID]?
+    'DECIDE' left=[Param:IDOrBackTickedID]? name=IDOrBackTickedID right=[Param:IDOrBackTickedID]?
     // can think of 'name' as 'head'
     'IF' body=Expr 
     /* The 'IF' here is more like a 'IFF' or 'just in case', rather than a mere 'if',


### PR DESCRIPTION
Had been on the fence about this because this doesn't always look good, but backticked param names seem like they might come up in the RF usecase.

Will also need to change the genitive syntax to make it look nicer, since right now we might have stuff like
```
`some applicant``s` publications < 2
```