### PR TITLE
`package.json`: Add `syntaxes` to `files`

### DIFF
--- a/lam4-frontend/package.json
+++ b/lam4-frontend/package.json
@@ -7,6 +7,7 @@
         "bin",
         "src",
         "out",
+        "syntaxes",
         "LICENSE"
     ],
     "repository": {


### PR DESCRIPTION
Fixes issue where syntax highlighting might not show up even when generated VSCode extension is used.