### PR TITLE
Langium Grammar: Improve genitive construct -- now `'s` instead of ``s``.

### DIFF
--- a/docs/proposal_normative_constructs_aug26_2024.md
+++ b/docs/proposal_normative_constructs_aug26_2024.md
@@ -111,8 +111,8 @@ For certain modelling purposes, of course, we may want richer structure, e.g.
 
 ```lam4
 ACTION TransferMoolah = DO {
-  Buyer`s`  money decreases_by 50
-  Seller`s` money increases_by 50
+  Buyer's  money decreases_by 50
+  Seller's money increases_by 50
 }
 ```
 

--- a/examples/PostfixPredicateApplication.l4
+++ b/examples/PostfixPredicateApplication.l4
@@ -14,7 +14,7 @@ IF True
 GIVEN (person: Person)
 DECIDE `is eligible`
 IF `some fact` HOLDS?
-AND f(1) + person`s` some_number EQUALS 2
+AND f(1) + person's some_number EQUALS 2
 
 DEFINE x: Person = {| some_number = 1 |}
 @REPORT x `is eligible`

--- a/examples/chained_record_deref.l4
+++ b/examples/chained_record_deref.l4
@@ -8,4 +8,4 @@ STRUCTURE G {
 }
 
 F => Integer
-f(x) = x`s` c`s` b
+f(x) = x's c's b

--- a/examples/not.l4
+++ b/examples/not.l4
@@ -3,11 +3,11 @@ STRUCTURE Applicant {
 }
 
 Applicant => Integer
-numberOfPublications(applicant) = applicant`s` publications
+numberOfPublications(applicant) = applicant's publications
 
 GIVEN (x IS_A Applicant)
 DECIDE `is eligible for grant`
-IF NOT x`s` publications < 2
+IF NOT x's publications < 2
 
 GIVEN (x IS_A Applicant)
 DECIDE `happy`

--- a/examples/predicate_and_givens_variations.l4
+++ b/examples/predicate_and_givens_variations.l4
@@ -9,7 +9,6 @@ IF True
 GIVEN (x IS_A Person 
        y IS_A Person 
        z IS_A Person)
-DECIDE pred2 IF x `s` age
+DECIDE pred2 IF x's age > 10 AND y's age > 10 AND z's age > 10
 
-GIVEN ()
 DECIDE no_givens_pred IF True

--- a/examples/simple_join_or_record_field_deref.l4
+++ b/examples/simple_join_or_record_field_deref.l4
@@ -5,11 +5,11 @@ STRUCTURE Applicant {
 DEFINE someApplicant: Applicant = {| publications = 1000 |}
 
 Applicant => Integer
-numberOfPublications(applicant) = applicant`s` publications
+numberOfPublications(applicant) = applicant's publications
 
 GIVEN (x IS_A Applicant)
 DECIDE `is eligible for grant`
-IF x`s` publications > 10
+IF x's publications > 10
 
 GIVEN (x IS_A Applicant)
 DECIDE `happy`

--- a/lam4-backend/src/Lam4/Expr/ConcreteSyntax.hs
+++ b/lam4-backend/src/Lam4/Expr/ConcreteSyntax.hs
@@ -224,8 +224,8 @@ Or:
 
 @
 ACTION TransferMoolah = DO {
-  Buyer`s`  money decreases_by 50
-  Seller`s` money increases_by 50
+  Buyer's  money decreases_by 50
+  Seller's money increases_by 50
 }
 @
 

--- a/lam4-frontend/src/language/lam4.langium
+++ b/lam4-frontend/src/language/lam4.langium
@@ -300,7 +300,7 @@ Mult infers Expr:
 (To be clear, the auto-linking/crossref for this won't work in the playground: https://github.com/eclipse-langium/langium/discussions/1502)
 */
 Project infers Expr:
-    InfixPredicateApplication ({infer Project.left=current} '`s`' right=Ref)*
+    InfixPredicateApplication ({infer Project.left=current} GENITIVE right=Ref)*
     // Right can't be [NamedElement:ID]
     // because we want the scoper to visit `left` first,
     // so that if `left`'s reference will be resolved via the default scoper/linker, if that's possible.
@@ -682,7 +682,7 @@ BooleanLiteral:
 /* =======================================
         TERMINALS
 ========================================== */
-
+terminal GENITIVE: "'s "; 
 hidden terminal WS: /\s+/;
 terminal ID: /[_a-zA-Z][\w_]*/;
 terminal INTEGER returns string: /((-|\\+)?[0-9]+)/;

--- a/lam4-frontend/src/language/type-system/infer.ts
+++ b/lam4-frontend/src/language/type-system/infer.ts
@@ -274,7 +274,7 @@ function synthProject(env: TypeEnv, term: Project): TypeTag {
 
     const rightRefName = term.right.value.$refText;
     
-    // With the type of the left sibling, we can infer what the type of `left `s` right` is
+    // With the type of the left sibling, we can infer what the type of `left 's right` is
     if (isRecordTTag(typeOfLeft)) {
         const recordTag = typeOfLeft;
 
@@ -295,7 +295,7 @@ function synthProject(env: TypeEnv, term: Project): TypeTag {
 /*
 Sep 3: The old Sig/Relations version (now currently just using Project without Join)
 --------------------------------------------------------------------------------------
-    // With the type of the left sibling, we can infer what the type of `left `s` right` is
+    // With the type of the left sibling, we can infer what the type of `left 's right` is
     if (isSigTTag(typeOfLeft)) {
         const sig = typeOfLeft.getSig();
         const matchingRelation: Relation | undefined = sig.relations.find(relNode => relNode.name === rightRefName);


### PR DESCRIPTION
The only remaining issue is that the auto-inferred syntax highlighting may not be very nice now -- may need to adjust that.

There may also be subtle precedence issues with the terminals that I haven't flushed out. @inariksit has agreed to give this a quick look; I'm going to just merge it in first, though, because even if there are precedence issues, fixing them should be easy.