### PR TITLE
Add list ops to Langium grammar; move away from braces to explicit `END` delimiter; add delimiter for function declarations to avoid clashes

### DIFF
--- a/examples/PostfixPredicateApplication.l4
+++ b/examples/PostfixPredicateApplication.l4
@@ -3,10 +3,13 @@
 /- 
 About: "A Person is pretty much what you would expect"
 -/
-STRUCTURE Person { some_number IS_A Integer }
+STRUCTURE Person 
+  some_number IS_A Integer 
+END
 
-Integer => Integer
+FUNCTION Integer => Integer
 f(x) = 2
+END
 
 DECIDE `some fact`
 IF True

--- a/examples/arithmetic.l4
+++ b/examples/arithmetic.l4
@@ -1,8 +1,10 @@
-Unit => Integer
+FUNCTION Unit => Integer
 f() = 3 + 5
+END
 
-Integer => Integer
+FUNCTION Integer => Integer
 g(x) = x * 2 - 1 / 3
+END
 
 @REPORT g(0)
 

--- a/examples/atomic_actions_transitive_if_then_infringed.l4
+++ b/examples/atomic_actions_transitive_if_then_infringed.l4
@@ -1,6 +1,6 @@
-ONE CONCEPT Buyer {}
-ONE CONCEPT Seller {}
-ONE CONCEPT Courier {}
+ONE CONCEPT Buyer END
+ONE CONCEPT Seller END
+ONE CONCEPT Courier END
 
 ACTION `pay for bike`
 ACTION `transfer bike to Courier within two days`

--- a/examples/chained_record_deref.l4
+++ b/examples/chained_record_deref.l4
@@ -1,11 +1,12 @@
-STRUCTURE F {
-    a: Integer
-    c: G
-}
+STRUCTURE F
+    a IS_A Integer
+    c IS_A G
+END
 
-STRUCTURE G {
-    b: Integer
-}
+STRUCTURE G
+    b IS_A Integer
+END
 
-F => Integer
+FUNCTION F => Integer
 f(x) = x's c's b
+END

--- a/examples/foldr_length.l4
+++ b/examples/foldr_length.l4
@@ -1,0 +1,21 @@
+STRUCTURE Publication END
+
+STRUCTURE Applicant
+    publications: Publication
+END
+
+FUNCTION Publication => Integer
+increment(_, acc) = acc + 1
+END
+
+FUNCTION Applicant => Integer
+numberOfPublications(applicant) =
+  FOLD_RIGHT 
+     using         increment
+     starting_with 0 
+     over          applicant's publications
+END
+
+GIVEN (applicant IS_A Applicant)
+DECIDE applicant `is eligible for grant`
+IF numberOfPublications(applicant) >= 3

--- a/examples/function_application.l4
+++ b/examples/function_application.l4
@@ -1,6 +1,7 @@
 // placeholder function for illustration
-Integer => Integer
+FUNCTION Integer => Integer
 sumIntegers(x, y) = x + y
+END
 
 DECIDE `some predicate`
 IF sumIntegers(1, 2) > 2

--- a/examples/infix_pred_app.l4
+++ b/examples/infix_pred_app.l4
@@ -3,7 +3,7 @@
 /- 
 About: "A Person is pretty much what you would expect"
 -/
-STRUCTURE Person {}
+STRUCTURE Person END
 
 // 'infix' predicate definition. The use of the params past the `DECIDE` is purely cosmetic. 
 GIVEN (some_person: Person 

--- a/examples/life_assured_predicate_fun_decl.l4
+++ b/examples/life_assured_predicate_fun_decl.l4
@@ -1,12 +1,11 @@
-STRUCTURE Accident { // placeholder
-}
+STRUCTURE Accident END // placeholder
 
-STRUCTURE LifeAssured {}
+STRUCTURE LifeAssured END
 
 -- Calculates how much the life assured can get for their claim
-LifeAssured => Accident => Integer
+FUNCTION LifeAssured => Accident => Integer
 payout(life_assured, accident) = 0
-  
+END  
 
 -- Checks if the life assured is eligible for a payout.
 GIVEN (x: LifeAssured)

--- a/examples/lottery.l4
+++ b/examples/lottery.l4
@@ -1,7 +1,7 @@
 /- About: "Info about a lottery." -/
-STRUCTURE Lottery {
+STRUCTURE Lottery
   -- how much can be won from the jackpot.
   total_jackpot: Integer
   -- whether buying tickets from this lottery is tax deductible.  
   `tax deductible status`: Boolean
-}
+END

--- a/examples/not.l4
+++ b/examples/not.l4
@@ -1,9 +1,10 @@
-STRUCTURE Applicant {
+STRUCTURE Applicant
     publications: Integer
-}
+END
 
-Applicant => Integer
+FUNCTION Applicant => Integer
 numberOfPublications(applicant) = applicant's publications
+END
 
 GIVEN (x IS_A Applicant)
 DECIDE `is eligible for grant`

--- a/examples/predicate_and_givens_variations.l4
+++ b/examples/predicate_and_givens_variations.l4
@@ -1,6 +1,6 @@
-STRUCTURE Person {
+STRUCTURE Person
     age: Integer
-}
+END
 
 DECIDE `pred blah blah`
 // use the backtick syntax when you want an identifier with spaces

--- a/examples/simple_atomic_actions_borrower_debt.l4
+++ b/examples/simple_atomic_actions_borrower_debt.l4
@@ -2,11 +2,11 @@
 DEFINE debt: Integer = 20
 
 
-ACTION `Borrower makes one loan installment` = DO {
+ACTION `Borrower makes one loan installment` = DO
     debt decreases_by 10
-}
+END
 
-ACTION `pay off debt` = DO {
+ACTION `pay off debt` = DO
     `Borrower makes one loan installment`
     then `Borrower makes one loan installment`
-}
+END

--- a/examples/simple_atomic_actions_with_party_sigs.l4
+++ b/examples/simple_atomic_actions_with_party_sigs.l4
@@ -1,5 +1,5 @@
-ONE CONCEPT Buyer {}
-ONE CONCEPT Seller {}
+ONE CONCEPT Buyer END
+ONE CONCEPT Seller END
 
 ACTION `pay for bike`
 ACTION `transfer bike to Buyer`

--- a/examples/simple_join_or_record_field_deref.l4
+++ b/examples/simple_join_or_record_field_deref.l4
@@ -1,11 +1,12 @@
-STRUCTURE Applicant {
+STRUCTURE Applicant
     publications: Integer
-}
+END
 
 DEFINE someApplicant: Applicant = {| publications = 1000 |}
 
-Applicant => Integer
+FUNCTION Applicant => Integer
 numberOfPublications(applicant) = applicant's publications
+END
 
 GIVEN (x IS_A Applicant)
 DECIDE `is eligible for grant`

--- a/examples/simple_life_assured.l4
+++ b/examples/simple_life_assured.l4
@@ -1,9 +1,9 @@
 /-
   About: "Information about the life assured for this policy."
 -/
-STRUCTURE LifeAssured {
+STRUCTURE LifeAssured
   -- whether policy active  
   policy_active: Boolean
   -- how old the life assured is
   age: Integer
-}
+END

--- a/lam4-frontend/src/language/lam4.langium
+++ b/lam4-frontend/src/language/lam4.langium
@@ -385,6 +385,10 @@ AnonFunction:
     body=Expr
 ;
 
+/* ============================
+    List and ListOps
+=============================== */
+
 List:
     EmptyList | NonEmptyList
 ;
@@ -395,12 +399,34 @@ EmptyList:
 ;
 
 NonEmptyList infers List:
-    'LIST_OF' elements+=Expr (',' elements+=Expr)* '.'
+    'LIST_OF' elements+=Expr (',' elements+=Expr)* ('.')?
 ;
 
+// TODO: Think more about what kind of surface syntax would be intuitive for foldr and foldl
+Foldr:
+    'FOLD_RIGHT' 'using' combine=Expr 'starting_with' nil=Expr 'over' collection=Expr
+;
+
+Foldl:
+    'FOLD_LEFT' 'using' update=Expr 'starting_with' initial=Expr 'over' collection=Expr
+;
+
+MaximumOf:
+    'MAXIMUM_OF' collection=Expr
+;
+
+MinimumOf:
+    'MINIMUM_OF' collection=Expr
+;
+
+SumOf:
+    'SUM_OF' collection=Expr
+;
+
+fragment ListOps: Foldr | Foldl | MaximumOf | MinimumOf | SumOf;
 
 PrimitiveExpr infers Expr:
-    '(' Expr ')' | AnonFunction | List
+    '(' Expr ')' | AnonFunction | List | ListOps
     | NormIsInfringed | Ref | UnaryExpr | IntegerLiteral | BooleanLiteral
     // Not sure if we want to allow for string literals as expressions
 ;

--- a/lam4-frontend/src/language/lam4.langium
+++ b/lam4-frontend/src/language/lam4.langium
@@ -190,12 +190,12 @@ FunDecl:
 
     // No GIVENs for this species of FunDecl -- having both the GIVEN syntax and the Typescripty params in parens syntax is too confusing
     // Require annotations for top level func decl, since required for bidir type checking
+    'FUNCTION' // An explicit kw might be helpful for non-programmers
     funType=TypeAnnot
-
-    'FUNCTION'? // An explicit kw might be helpful for non-programmers
     name=ID '(' ( params+=Param (',' params+=Param)* )? ')'
     ( '=' | 'equals')
     body=Expr
+    'END'
 ;
 
 // When doing concrete (as opposed to symbolic) execution,
@@ -489,13 +489,13 @@ ActionDecl:
     ('=' PrimActionBlock)?
 ;
 
-fragment PrimActionBlock: 'DO' '{'
+fragment PrimActionBlock: 'DO'
     actions+=PrimAction ('then' actions+=PrimAction)*
-'}';
+'END';
 
-fragment StatementBlock: 'DO' '{'
+fragment StatementBlock: 'DO'
     statements+=Statement+
-'}';
+'END';
 
 Norm:
     originalRuleRef=OriginalRuleRef?
@@ -524,9 +524,9 @@ RecordDecl:
 
     'STRUCTURE'
     name=ID
-    ( 'SPECIALIZES' parents+=[RecordDecl:ID] ( ',' parents+=[RecordDecl:ID] )* )? '{'
+    ( 'SPECIALIZES' parents+=[RecordDecl:ID] ( ',' parents+=[RecordDecl:ID] )* )?
         rowTypes+=RowType*
-    '}'
+    'END'
 ;
 
 
@@ -577,9 +577,9 @@ SigDecl:
 
     multiplicity=SigMultOne? 'CONCEPT'
     name=ID
-    ( 'SPECIALIZES' parents+=[SigDecl:ID] ( ',' parents+=[SigDecl:ID] )* )? '{'
+    ( 'SPECIALIZES' parents+=[SigDecl:ID] ( ',' parents+=[SigDecl:ID] )* )?
         relations+=Relation*
-    '}'
+    'END'
 ;
 
 SigMultOne: {infer SigMultOne} 'ONE';


### PR DESCRIPTION
List Ops parsing haven't been added to backend yet --- that's for the next PR