### PR TITLE
Add hetero equality; fix List backend parsing regression

### DIFF
--- a/examples/heterogeneous.l4
+++ b/examples/heterogeneous.l4
@@ -1,0 +1,17 @@
+// TODO: The translation of names of ONE CONCEPT / atoms needs to be fixed
+// ScopeError "Unknown_1"
+
+ONE CONCEPT Unknown END
+
+DEFINE list = LIST_OF 1, 2, Unknown, 3, 4
+
+FUNCTION (Integer => Integer) => LIST_OF Integer
+map(f, xs) = 
+  FOLD_RIGHT 
+    using         (\x acc => f(x) followed_by_items_in acc)
+    starting_with EMPTY_LIST
+    over          xs
+END
+
+@REPORT map(\x => x EQUALS Unknown, list)
+@REPORT map(\x => x EQUALS 2,       list)

--- a/lam4-backend/src/Lam4/Expr/ConcreteSyntax.hs
+++ b/lam4-backend/src/Lam4/Expr/ConcreteSyntax.hs
@@ -71,9 +71,6 @@ data Expr
   | Unary      UnaryOp Expr
   | BinExpr    BinOp Expr Expr
   | IfThenElse Expr Expr Expr
-  -- TODO: Not Yet Implemented / need to think more about what collection types to support
-  -- TODO: Add Cons after have wired up to an evaluator
-  -- | ListExpr   ListOp [Expr]
   | FunApp     Expr [Expr]
   | Record     (Row Expr)                          -- record construction
   | Project    Expr Name                           -- record projection
@@ -260,6 +257,8 @@ exprSubexprsVL f = \case
   -- Exprs with sub-exprs
   Cons first rest                    -> Cons <$> f first <*> f rest
   List xs                            -> List <$> traverse f xs
+  Foldr combine nil xs               -> Foldr <$> f combine <*> f nil <*> f xs
+  Foldl update initial xs            -> Foldl <$> f update <*> f initial <*> f xs
   Unary op expr                      -> Unary op <$> f expr
   BinExpr op left right              -> BinExpr op <$> f left <*> f right
   IfThenElse cond thn els            -> IfThenElse <$> f cond <*> f thn <*> f els

--- a/lam4-backend/src/Lam4/Expr/Parser.hs
+++ b/lam4-backend/src/Lam4/Expr/Parser.hs
@@ -433,7 +433,7 @@ parseIfThenElse obj = do
 
 parseList :: A.Object -> Parser Expr
 parseList listNode = do
-  elts <- traverse parseExpr (listNode `getObjectsAtField` "elts")
+  elts <- traverse parseExpr (listNode `getObjectsAtField` "elements")
   pure $ List elts
 
 parseCons :: A.Object -> Parser Expr

--- a/lam4-backend/src/Lam4/Expr/ToSimala.hs
+++ b/lam4-backend/src/Lam4/Expr/ToSimala.hs
@@ -69,7 +69,8 @@ compileBinOp = \case
   Le     -> SM.Le
   Ge     -> SM.Ge
   Ne     -> SM.Ne
-  Eq     -> SM.Eq
+  Eq     -> SM.HEq 
+  -- TODO: in the future, could pass along type info and use that to determine if we should use HEq or Eq
   Modulo -> SM.Modulo
   StrAppend -> SM.Append
 


### PR DESCRIPTION
* Fixes regression in backend parsing of List
* add Foldr, Foldl variants to Traversable instance
* Add heterogeneous equality example -- right now, this is NOT translated correctly to Simala (TODO)

```
❯ cabal run lam4-cli -- examples/heterogeneous.l4
Resolving dependencies...
"------- CST -------------"
[ NonRec "Unknown" _1 (Sig [] [])
, NonRec
    "list"
    _2
    (List
       [ Lit (IntLit 1)
       , Lit (IntLit 2)
       , Var "Unknown" _1
       , Lit (IntLit 3)
       , Lit (IntLit 4)
       ])
, Rec
    "map"
    _3
    (Fun
       RuleMetadata
         { originalRuleRef = Nothing
         , transparency = Transparent
         , description = Nothing
         }
       [ "f" _6 , "xs" _7 ]
       (Foldr
          (Fun
             RuleMetadata
               { originalRuleRef = Nothing
               , transparency = Transparent
               , description = Nothing
               }
             [ "x" _4 , "acc" _5 ]
             (Cons (FunApp (Var "f" _6) [ Var "x" _4 ]) (Var "acc" _5)))
          (List [])
          (Var "xs" _7)))
, Eval
    (FunApp
       (Var "map" _3)
       [ Fun
           RuleMetadata
             { originalRuleRef = Nothing
             , transparency = Transparent
             , description = Nothing
             }
           [ "x" _8 ]
           (BinExpr Eq (Var "x" _8) (Var "Unknown" _1))
       , Var "list" _2
       ])
, Eval
    (FunApp
       (Var "map" _3)
       [ Fun
           RuleMetadata
             { originalRuleRef = Nothing
             , transparency = Transparent
             , description = Nothing
             }
           [ "x" _9 ]
           (BinExpr Eq (Var "x" _9) (Lit (IntLit 2)))
       , Var "list" _2
       ])
]
"-------- Simala exprs ---------"
 opaque decl_Unknown_1 = 'Unknown_1
 opaque list_2 = [1,2,Unknown_1,3,4]
rec map_3 = fun (f_6,xs_7) => foldr(fun (x_4,acc_5) => f_6(x_4) : acc_5,[],xs_7)
#eval map_3(fun (x_8) => x_8 ~= Unknown_1,list_2)
#eval map_3(fun (x_9) => x_9 ~= 2,list_2)
"-------------------------------"
ScopeError "Unknown_1"
```