### PR TITLE
Allow RecordDecl, FunDecl, SigDecl names to be backticked ID

### DIFF
--- a/lam4-frontend/src/language/lam4.langium
+++ b/lam4-frontend/src/language/lam4.langium
@@ -559,8 +559,8 @@ RecordDecl:
     WithSpecificMetadataBlock?
 
     'STRUCTURE'
-    name=ID
-    ( 'SPECIALIZES' parents+=[RecordDecl:ID] ( ',' parents+=[RecordDecl:ID] )* )?
+    name=IDOrBackTickedID
+    ( 'SPECIALIZES' parents+=[RecordDecl:IDOrBackTickedID] ( ',' parents+=[RecordDecl:IDOrBackTickedID] )* )?
         rowTypes+=RowType*
     'END'
 ;
@@ -612,8 +612,8 @@ SigDecl:
     WithSpecificMetadataBlock?
 
     multiplicity=SigMultOne? 'CONCEPT'
-    name=ID
-    ( 'SPECIALIZES' parents+=[SigDecl:ID] ( ',' parents+=[SigDecl:ID] )* )?
+    name=IDOrBackTickedID
+    ( 'SPECIALIZES' parents+=[SigDecl:IDOrBackTickedID] ( ',' parents+=[SigDecl:IDOrBackTickedID] )* )?
         relations+=Relation*
     'END'
 ;

--- a/lam4-frontend/src/language/lam4.langium
+++ b/lam4-frontend/src/language/lam4.langium
@@ -201,7 +201,7 @@ FunDecl:
     // Require annotations for top level func decl, since required for bidir type checking
     'FUNCTION' // An explicit kw might be helpful for non-programmers
     funType=TypeAnnot
-    name=ID 
+    name=IDOrBackTickedID 
     FunParams
     ( '=' | 'equals')
     body=Expr
@@ -642,7 +642,7 @@ Relation:
     // WithSpecificMetadataBlock?
     description=SINGLELINE_METADATA_ANNOTATION?
 
-    name=ID
+    name=IDOrBackTickedID
     // optional?='?'?
     (':' | 'IS_A')
     relatum=TypeAnnot // TODO: Support plural relata


### PR DESCRIPTION
I think I had wanted to impose some restrictions in the past on where backticked IDs could be used, for cosmetic reasons, but the RF usecase is showing me that that doesn't make sense.