### PR TITLE
Langium grammar: Fix some Let issues: var bindings in `LetExpr` and nesting Let

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -7,7 +7,7 @@ packages:
 source-repository-package
   type: git
   location: https://github.com/smucclaw/simala
-  tag: a346fa8407082bc1c803f91e2475c16c6743036a
+  tag: 891511dd9a73f936ae1c0171fca26eec5f9e2d2c
 
 
 package *

--- a/examples/chained_record_deref.l4
+++ b/examples/chained_record_deref.l4
@@ -1,3 +1,7 @@
+// ---------------------------------------------------------------------------------
+// TODO: This is more of a test than an example. Will move into tests in the future.
+// ---------------------------------------------------------------------------------
+
 STRUCTURE F
     a IS_A Integer
     c IS_A G

--- a/examples/let.l4
+++ b/examples/let.l4
@@ -1,0 +1,7 @@
+@REPORT 
+LET { 
+    x = 1,
+    y = 2 } 
+IN { 
+  x + y * y 
+}

--- a/examples/let2_shadowing.l4
+++ b/examples/let2_shadowing.l4
@@ -1,3 +1,8 @@
+// ---------------------------------------------------------------------------------
+// TODO: This is more of a test than an example. Will move into tests in the future.
+// ---------------------------------------------------------------------------------
+
+// Test shadowing and scoping of LET expressions
 @REPORT 
 LET { 
     x = 1,

--- a/examples/let2_shadowing.l4
+++ b/examples/let2_shadowing.l4
@@ -1,0 +1,7 @@
+@REPORT 
+LET { 
+    x = 1,
+    y = LET { x = 10 } IN { x } } 
+IN { 
+  x + y * y 
+}

--- a/examples/let2_shadowing.l4
+++ b/examples/let2_shadowing.l4
@@ -3,5 +3,5 @@ LET {
     x = 1,
     y = LET { x = 10 } IN { x } } 
 IN { 
-  x + y * y 
+  x + y 
 }

--- a/examples/let_backticked_id.l4
+++ b/examples/let_backticked_id.l4
@@ -1,0 +1,10 @@
+DEFINE `something something` = 100
+
+@REPORT 
+LET { 
+    x                is 1,
+    `blah blah`      is `something something` - 1,
+    `something else` is 1 - `blah blah` + 2} 
+IN { 
+    x + `blah blah`
+}

--- a/examples/nested_let_shadowing.l4
+++ b/examples/nested_let_shadowing.l4
@@ -1,0 +1,12 @@
+// ---------------------------------------------------------------------------------
+// TODO: This is more of a test than an example. Will move into tests in the future.
+// ---------------------------------------------------------------------------------
+
+// Test nested let x scoping / shadowing
+@REPORT 
+LET {  
+    z = 2,
+    x = 1
+} IN { 
+    LET { x = 100} IN { x }
+}

--- a/lam4-backend/src/Lam4/Expr/Parser.hs
+++ b/lam4-backend/src/Lam4/Expr/Parser.hs
@@ -61,7 +61,7 @@ import           Lam4.Parser.Type
 -- | The Langium-parser ASTNode `$type`s that correspond to recursive exprs
 recursiveTypes :: Set Text
 recursiveTypes = Set.fromList ["LetExpr", "FunDecl", "PredicateDecl"]
--- TODO: Check how to handle Let vs Let rec in translation to Simala!
+-- TODO: Improve translation of LetExpr when it comes to LetRec vs Let (if necessary)
 
 
 {----------------------

--- a/lam4-backend/src/Lam4/Expr/Parser.hs
+++ b/lam4-backend/src/Lam4/Expr/Parser.hs
@@ -61,6 +61,8 @@ import           Lam4.Parser.Type
 -- | The Langium-parser ASTNode `$type`s that correspond to recursive exprs
 recursiveTypes :: Set Text
 recursiveTypes = Set.fromList ["LetExpr", "FunDecl", "PredicateDecl"]
+-- TODO: Check how to handle Let vs Let rec in translation to Simala!
+
 
 {----------------------
     Ref

--- a/lam4-frontend/src/language/lam4.langium
+++ b/lam4-frontend/src/language/lam4.langium
@@ -261,8 +261,9 @@ AndExpr infers Expr:
 ;
 
 // TODO: Not sure if VarDecl the best thing to use for the inner stuff
+// TODO: Will switch from braces to indentation when time permits
 LetExpr:
-    'LET' '{' (vars+=VarBinding)+ '}' 'IN' '{' body=OrExpr '}'
+    'LET' '{' vars+=VarBinding (',' vars+=VarBinding )* '}' 'IN' '{' body=OrExpr '}'
 ;
 
 Row:

--- a/lam4-frontend/src/language/lam4.langium
+++ b/lam4-frontend/src/language/lam4.langium
@@ -245,7 +245,7 @@ IDOrBackTickedID returns string:
 =============================== */
 
 Expr:
-    OrExpr | LetExpr | RecordExpr
+    OrExpr | RecordExpr
     // TODO: Check if adding LetExpr to the grammar in this way is compositional enough
 ;
 
@@ -263,7 +263,12 @@ AndExpr infers Expr:
 // TODO: Not sure if VarDecl the best thing to use for the inner stuff
 // TODO: Will switch from braces to indentation when time permits
 LetExpr:
-    'LET' '{' vars+=VarBinding (',' vars+=VarBinding )* '}' 'IN' '{' body=OrExpr '}'
+    'LET' 
+        '{' 
+            vars+=VarBinding (',' vars+=VarBinding )* 
+        '}' 'IN' '{' 
+            body=ComparisonExpr 
+        '}'
 ;
 
 Row:
@@ -437,7 +442,7 @@ SumOf:
 fragment ListOps: Foldr | Foldl | MaximumOf | MinimumOf | SumOf;
 
 PrimitiveExpr infers Expr:
-    '(' Expr ')' | AnonFunction | List | ListOps
+    '(' Expr ')' | AnonFunction | List | ListOps | LetExpr
     | NormIsInfringed | Ref | UnaryExpr | IntegerLiteral | BooleanLiteral | StringLiteral
     // Not sure if we want to allow for string literals as expressions
 ;

--- a/scripts/cabal-run-examples.sh
+++ b/scripts/cabal-run-examples.sh
@@ -7,7 +7,8 @@ RESET='\033[0m'
 error_files=()
 error_outputs=()
 
-for file in examples/*.l4; do
+# Skip files with "action" in their name
+for file in $(find examples -name "*.l4" | grep -v "action"); do
     output=$(cabal run lam4-cli -- "$file" 2>&1)
     exit_status=$?
     echo "$output"
@@ -21,7 +22,7 @@ done
 if [ ${#error_files[@]} -ne 0 ]; then
     echo;
     echo -e "${RED}==========================================================${RESET}"
-    echo -e "${RED}  Files with errors (ignore ActionDecl-related errors)${RESET}"
+    echo -e "${RED}  Non-actions-using programs with errors${RESET}"
     echo -e "${RED}==========================================================${RESET}"
     echo;
 
@@ -30,5 +31,5 @@ if [ ${#error_files[@]} -ne 0 ]; then
         echo -e "${RED}${error_outputs[$i]}${RESET}"
     done
 else
-    echo -e "${GREEN}All .l4 files in examples dir ran successfully.${RESET}"
+    echo -e "${GREEN}All .l4 files without 'action' in filename in examples dir ran successfully.${RESET}"
 fi


### PR DESCRIPTION
Fixes (i) var bindings in Let Expr and (ii) nesting Let expressions in surface syntax, e.g.
```lam4
LET {  
    z = 2,
    x = 1
} IN { 
    LET { x = 100} IN { x }
}
```

## The following is superseded and preserved only for posterity

I did, however, run into the following issue; seems to be due to `let rec` vs `let`:

## The Simala error

Lam4 input program
```lam4
@REPORT 
LET { 
    x = 1,
    y = LET { x = 10 } IN { x } } 
IN { 
  x + y * y 
}
```

The parsed-into-backend Lam4 concrete syntax; the shadowing was correctly picked up on
```
Eval
    (Let
       (NonRec "x" _1 (Lit (IntLit 1)))
       (Let
          (Rec "y" _2 (Let (NonRec "x" _3 (Lit (IntLit 10))) (Var "x" _3)))
          (BinExpr
             Plus (Var "x" _1) (BinExpr Mult (Var "y" _2) (Var "y" _2)))))
```

Simala exprs and eval
```
#eval let opaque x_1 = 1 in letrec opaque y_2 = let opaque x_3 = 10 in x_3 in x_1 + y_2 * y_2
"-------------------------------"
x_1 = 1
y_2 = 10
TypeError [TFun] TInt
```

## Diagnosis

This seems to be due to let rec vs let, judging from these quick Simala experiments:

```simala
> let x =1 in let y = (let x = 10 in x) in x + y * y
101
```

but

```simala
> let rec x =1 in let y = (let x = 10 in x) in x + y * y
TypeError [TFun] TInt
```

My current takeaway: I was basically translating Lets in a Decl to a Rec Decl by default, but this suggests I should do some analysis and only do translate it to a Let rec if the let is actually recursive? Not sure. Will look at how fendor did it in the main-branch L4 translation if time permits.