### PR TITLE
Refactor Integer, add Fractionals / DecimalLiteral. 

### DIFF
--- a/examples/decimal.l4
+++ b/examples/decimal.l4
@@ -1,0 +1,17 @@
+@REPORT 1.333
+// TODO: would be good to figure out a better way of doing the following
+@REPORT 1333.0 / 1000.0
+// edge case to think about for future
+@REPORT 1.0 / 1000.0 + 333.0 / 1000.0
+
+@REPORT 1.0
+@REPORT 1
+
+@REPORT 0.00
+@REPORT 0
+
+@REPORT 1.0 + 0.333
+
+// Sep 23: FYI, things that do NOT parse:
+// @REPORT .0
+// @REPORT 0.

--- a/examples/fractionals.l4
+++ b/examples/fractionals.l4
@@ -1,0 +1,11 @@
+DEFINE fractional = 0.5 * 0.5
+DEFINE negative = -0.3
+DEFINE squared = negative * negative
+
+@REPORT fractional
+// for next PR
+// @REPORT floor(fractional);
+// @REPORT ceiling(fractional);
+// @REPORT fractional * fromInt(2);
+@REPORT negative
+// @REPORT squared;

--- a/examples/fractionals.l4
+++ b/examples/fractionals.l4
@@ -8,4 +8,4 @@ DEFINE squared = negative * negative
 // @REPORT ceiling(fractional);
 // @REPORT fractional * fromInt(2);
 @REPORT negative
-// @REPORT squared;
+@REPORT squared

--- a/examples/unary_minus_integer.l4
+++ b/examples/unary_minus_integer.l4
@@ -1,0 +1,20 @@
+DEFINE negativeIntegerLiteralZero = -0
+DEFINE negativeInteger = -3
+DEFINE squared = negativeInteger * negativeInteger
+
+DEFINE subtracted = 0 - 3 + 0 + 1 - 1
+
+@REPORT negativeIntegerLiteralZero
+@REPORT negativeIntegerLiteralZero EQUALS 0
+@REPORT negativeInteger
+@REPORT negativeInteger EQUALS -3
+
+@REPORT squared
+
+@REPORT subtracted
+@REPORT subtracted * subtracted EQUALS squared
+
+// The following does NOT work -- will need to use an explicit negate function
+// since will be disconnecting type checker and can't tell if it's an Int or Frac without the types
+// DEFINE negatedSubtracted = -subtracted
+// @REPORT negatedSubtracted

--- a/lam4-backend/src/Base/Text.hs
+++ b/lam4-backend/src/Base/Text.hs
@@ -1,4 +1,5 @@
 module Base.Text (module X) where
 
 import Data.Text as X
+import Data.Text.Read as X
 import Data.Text.IO as X

--- a/lam4-backend/src/Lam4/Expr/ConcreteSyntax.hs
+++ b/lam4-backend/src/Lam4/Expr/ConcreteSyntax.hs
@@ -108,8 +108,9 @@ data Expr
 
 -- TODO: tweak the grammar to distinguish between integers and non-integers
 data Lit
-  = IntLit Int
-  | BoolLit Bool
+  = IntLit    Int
+  | FracLit   Double
+  | BoolLit   Bool
   | StringLit Text
   deriving stock (Eq, Show, Ord)
 

--- a/lam4-backend/src/Lam4/Expr/Parser.hs
+++ b/lam4-backend/src/Lam4/Expr/Parser.hs
@@ -220,6 +220,7 @@ parseExpr node = do
 
     -- literals
     "IntegerLiteral" -> parseIntegerLiteral node
+    "DecimalLiteral" -> parseDecimalLiteral node
     "StringLiteral"  -> parseStringLiteral node
     "BooleanLiteral" -> parseBooleanLiteral node
 
@@ -679,6 +680,25 @@ parseIntegerLiteral literalNode = do
     case literalVal of
       Just litVal -> pure . Lit $ IntLit litVal
       Nothing -> throwError $ "Failed to parse integer value. Node: " <> ppShow literalNode
+
+{- | Example of DecimalLiteral node:
+
+@
+  {
+    "$type": "DecimalLiteral",
+    "value": "1.333"
+  }
+@
+-}
+parseDecimalLiteral :: A.Object -> Parser Expr
+parseDecimalLiteral literalNode = do
+    let literalVal = literalNode ^? ix "value" % _String
+    case literalVal of
+      Just litVal ->
+        case T.rational litVal of
+          Right (litVal', _) -> pure . Lit $ FracLit litVal'
+          Left err -> throwError $ "Failed to parse decimal literal. " <> err <>  "Node: " <> ppShow literalNode 
+      Nothing -> throwError $ "Failed to parse decimal literal. Node: " <> ppShow literalNode
 
 parseBooleanLiteral :: A.Object -> Parser Expr
 parseBooleanLiteral literalNode = do

--- a/lam4-backend/src/Lam4/Expr/ToSimala.hs
+++ b/lam4-backend/src/Lam4/Expr/ToSimala.hs
@@ -109,6 +109,7 @@ compileExpr :: AST.ConEvalExpr -> SM.Expr
 compileExpr = \case
   Var name                     -> SM.Var $ lam4ToSimalaName name
   Lit (CST.IntLit i)           -> SM.Lit $ SM.IntLit i
+  Lit (CST.FracLit fractional) -> SM.Lit $ SM.FracLit fractional
   Lit (CST.BoolLit b)          -> SM.Lit $ SM.BoolLit b
   Lit (CST.StringLit s)        -> SM.Lit $ SM.StringLit s
   Cons first rest              -> SM.Cons (compileExpr first) (compileExpr rest)

--- a/lam4-backend/src/Lam4/Expr/ToSimala.hs
+++ b/lam4-backend/src/Lam4/Expr/ToSimala.hs
@@ -38,6 +38,11 @@ import qualified Simala.Expr.Type         as SM
 defaultTransparency :: SM.Transparency
 defaultTransparency = SM.Opaque
 
+simalaNegativeOneInt :: SM.Expr
+simalaNegativeOneInt = SM.Lit $ SM.IntLit (-1)
+
+simalaNegativeOneFrac :: SM.Expr
+simalaNegativeOneFrac = SM.Lit $ SM.FracLit (-1.0)
 
 type SimalaDecl = SM.Decl
 type SimalaProgram = [SM.Decl]
@@ -69,7 +74,7 @@ compileBinOp = \case
   Le     -> SM.Le
   Ge     -> SM.Ge
   Ne     -> SM.Ne
-  Eq     -> SM.HEq 
+  Eq     -> SM.HEq
   -- TODO: in the future, could pass along type info and use that to determine if we should use HEq or Eq
   Modulo -> SM.Modulo
   StrAppend -> SM.Append
@@ -114,6 +119,11 @@ compileExpr = \case
   Lit (CST.StringLit s)        -> SM.Lit $ SM.StringLit s
   Cons first rest              -> SM.Cons (compileExpr first) (compileExpr rest)
   List xs                      -> SM.List (map compileExpr xs)
+
+  -- translate unary minus x to @-1 * x@, accounting for Int vs Frac literals
+  -- This obviously won't be enough for applications of UnaryMinus to a non-literal (since can't tell if it's an Int or Frac)
+  Unary UnaryMinus lit@(Lit (CST.IntLit _)) -> SM.Builtin SM.Product [simalaNegativeOneInt, compileExpr lit]
+  Unary UnaryMinus lit@(Lit (CST.FracLit _)) -> SM.Builtin SM.Product [simalaNegativeOneFrac, compileExpr lit]
   Unary op expr                -> SM.Builtin (compileUnaryOp op) [compileExpr expr]
   BinExpr op left right        -> SM.Builtin (compileBinOp op) [compileExpr left, compileExpr right]
   IfThenElse cond thn els      -> SM.Builtin SM.IfThenElse [compileExpr cond, compileExpr thn, compileExpr els]

--- a/lam4-frontend/src/language/lam4.langium
+++ b/lam4-frontend/src/language/lam4.langium
@@ -443,7 +443,7 @@ fragment ListOps: Foldr | Foldl | MaximumOf | MinimumOf | SumOf;
 
 PrimitiveExpr infers Expr:
     '(' Expr ')' | AnonFunction | List | ListOps | LetExpr
-    | NormIsInfringed | Ref | UnaryExpr | IntegerLiteral | BooleanLiteral | StringLiteral
+    | NormIsInfringed | Ref | UnaryExpr | IntegerLiteral | DecimalLiteral | BooleanLiteral | StringLiteral
     // Not sure if we want to allow for string literals as expressions
 ;
 
@@ -709,6 +709,10 @@ IntegerLiteral:
     value=INTEGER
 ;
 
+DecimalLiteral:
+    value=DECIMAL
+;
+
 StringLiteral:
     value=STRING
 ;
@@ -717,17 +721,22 @@ BooleanLiteral:
     value=('True' | 'False')
 ;
 
-// Decimal returns string:
-//     INT ('.' INT)?;
-
 
 /* =======================================
         TERMINALS
 ========================================== */
+
+// Note: The order of the terminals matters: the lexer will always return the first match
+// See https://langium.org/docs/grammar-language/#terminal-rules
+
 terminal GENITIVE: "'s "; 
 hidden terminal WS: /\s+/;
 terminal ID: /[_a-zA-Z][\w_]*/;
-terminal INTEGER returns string: /((-|\\+)?[0-9]+)/;
+
+terminal DECIMAL returns string: INTEGER '.' INTEGER;
+terminal INTEGER returns string: /[0-9]+/;
+// terminal INTEGER returns string: /((-|\\+)?[0-9]+)/;
+
 // terminal NUMBER returns number: /[0-9]+(\.[0-9]+)?/;
 // terminal SIGNED_NUMBER returns number: /-\d+((\.\d+)?([eE][\-+]?\d+)?)?/;
 // terminal UNSIGNED_NUMBER returns string: /\d+((\.\d+)?([eE][\-+]?\d+)?)?/;


### PR DESCRIPTION
1. Add fractionals / decimalliteral
2. ToSimala: Translate unary minus literal patterns to `-1 * x`, accounting for Int vs Frac literals
This obviously won't be enough for applications of UnaryMinus to a non-literal (since can't tell if it's an Int or Frac). For those, will need a `negate` function. The `negate` function can be made a std lib function if time permits.


Examples:

```
DEFINE fractional = 0.5 * 0.5
DEFINE negative = -0.3
DEFINE squared = negative * negative
 
@REPORT fractional
// for next PR
// @REPORT floor(fractional);
// @REPORT ceiling(fractional);
// @REPORT fractional * fromInt(2);
@REPORT negative
@REPORT squared
```

outputs as

```
❯ cabal run lam4-cli -- examples/fractionals.l4
"------- CST -------------"
[ NonRec
    "fractional"
    _1
    (BinExpr Mult (Lit (FracLit 0.5)) (Lit (FracLit 0.5)))
, NonRec "negative" _2 (Unary UnaryMinus (Lit (FracLit 0.3)))
, NonRec
    "squared" _3 (BinExpr Mult (Var "negative" _2) (Var "negative" _2))
, Eval (Var "fractional" _1)
, Eval (Var "negative" _2)
, Eval (Var "squared" _3)
]
"-------- Simala exprs ---------"
 opaque fractional_1 = 0.5 * 0.5
 opaque negative_2 = -1.0 * 0.3
 opaque squared_3 = negative_2 * negative_2
#eval fractional_1
#eval negative_2
#eval squared_3
"-------------------------------"
0.25
-0.3
9.0e-2
```