### PR TITLE
Fix the auto-inferred / auto-generated genitive syntax highlighting by removing single quotes from `STRING` terminal

### DIFF
--- a/examples/chained_record_deref.l4
+++ b/examples/chained_record_deref.l4
@@ -1,7 +1,9 @@
 // ---------------------------------------------------------------------------------
 // TODO: This is more of a test than an example. Will move into tests in the future.
 // ---------------------------------------------------------------------------------
-
+/- 
+    About: "a description could go here"
+-/
 STRUCTURE F
     a IS_A Integer
     c IS_A G
@@ -13,4 +15,10 @@ END
 
 FUNCTION F => Integer
 f(x) = x's c's b
+END
+
+@REPORT "test syntax highlighting"
+
+FUNCTION F => Integer
+f(x) = x's a + 2 
 END

--- a/lam4-frontend/src/language/lam4.langium
+++ b/lam4-frontend/src/language/lam4.langium
@@ -750,10 +750,9 @@ terminal DECIMAL returns string: INTEGER '.' INTEGER;
 terminal INTEGER returns string: /[0-9]+/;
 // terminal INTEGER returns string: /((-|\\+)?[0-9]+)/;
 
-// terminal NUMBER returns number: /[0-9]+(\.[0-9]+)?/;
-// terminal SIGNED_NUMBER returns number: /-\d+((\.\d+)?([eE][\-+]?\d+)?)?/;
-// terminal UNSIGNED_NUMBER returns string: /\d+((\.\d+)?([eE][\-+]?\d+)?)?/;
-terminal STRING: /"(\\.|[^"\\])*"|'(\\.|[^'\\])*'/;
+// terminal STRING: /"(\\.|[^"\\])*"|'(\\.|[^'\\])*'/;
+// Don't allow single quotes as delimiters for strings
+terminal STRING: /"(\\.|[^"\\])*"/;
 terminal BACK_TICKED_ID:
     '`' -> '`'
 ;


### PR DESCRIPTION
`chained_record_deref.l4` looks like this for me now

<img width="405" alt="image" src="https://github.com/user-attachments/assets/d3359317-2a3d-4979-8273-f2e706e5a7ee">

@johsi-k could you help me check if it looks ok when you build an extension and look at that file too?

This doesn't yet fix all auto-generated syntax highlighting issues: e.g., it's not great that `is` is highlighted in the following. But at least it seems to fix the most glaring syntax highlighting issue.

![image](https://github.com/user-attachments/assets/872386ee-7e1e-4d5e-b6fd-97a60896cb86)

