### PR TITLE
Make type annots optional; Fix: Make parsing of record expr labels consistent with demo hack

### DIFF
--- a/examples/functions_with_no_type_annots.l4
+++ b/examples/functions_with_no_type_annots.l4
@@ -1,0 +1,10 @@
+// ---------------------------------------------------------------------------------
+// TODO: This is more of a test than an example. Will move into tests in the future.
+// ---------------------------------------------------------------------------------
+FUNCTION
+f(x) = x's c's b
+END
+
+FUNCTION
+g(x) = 1 - x's a + 2 
+END

--- a/lam4-backend/src/Lam4/Expr/Parser.hs
+++ b/lam4-backend/src/Lam4/Expr/Parser.hs
@@ -254,7 +254,7 @@ parseExpr node = do
 
     -}
     "SigDecl"        -> parseSigE           node
-    "RecordExpr"     -> parseRecordExpr     node
+    "RecordExpr"     -> parseRecordExprForDemo     node
     "Project"        -> parseProject        node
 
     typestr          -> throwError $ T.unpack typestr <> " not yet implemented"
@@ -317,6 +317,19 @@ parseBinExpr node = do
   left  <- parseExpr  =<< node .: "left"
   right <- parseExpr  =<< node .: "right"
   pure $ BinExpr op left right
+
+parseRecordExprForDemo :: A.Object -> Parser Expr
+parseRecordExprForDemo node = do
+  rows <- traverse mkBinding (node `getObjectsAtField` "rows")
+  pure $ Record rows
+  where
+    mkBinding :: A.Object -> Parser (Name, Expr)
+    mkBinding row = do
+      labelName <- row .: "label"
+      let name = MkName labelName uniqueForNamesThatShouldNotHaveUniqueAppended
+      expr <- parseExpr =<< row .: "value"
+      pure (name, expr)
+
 
 {- | Key invariant for the parsing:
   Record expressions have to be constructed / parsed in such a way that:

--- a/lam4-frontend/src/language/lam4.langium
+++ b/lam4-frontend/src/language/lam4.langium
@@ -164,7 +164,7 @@ Param:
     name=IDOrBackTickedID;
 
 ParamTypePair:
-    param=Param (':' | 'IS_A') type=TypeAnnot
+    param=Param (':' | 'IS_A') type=TypeAnnot?
 ;
 
 // ------- PredicateDecl, FunDecl -------
@@ -200,7 +200,7 @@ FunDecl:
     // No GIVENs for this species of FunDecl -- having both the GIVEN syntax and the Typescripty params in parens syntax is too confusing
     // Require annotations for top level func decl, since required for bidir type checking
     'FUNCTION' // An explicit kw might be helpful for non-programmers
-    funType=TypeAnnot
+    funType=TypeAnnot?
     name=IDOrBackTickedID 
     FunParams
     ( '=' | 'equals')


### PR DESCRIPTION
1. Langium Grammar: Make type annots optional
2. Fix: Make parsing of record expr labels consistent with demo hack