### PR TITLE
Output NLG result in generated/nlg_en/output.txt

### DIFF
--- a/lam4-backend/src/Lam4/Render/Render.hs
+++ b/lam4-backend/src/Lam4/Render/Render.hs
@@ -24,6 +24,7 @@ type GFLinearizer = PGF.Tree -> T.Text
 -- | Config that stores info about paths and various other NLG configuration things
 data NLGConfig = MkNLGConfig {
       outputDir              :: FilePath
+    , resultFilename         :: FilePath
     , abstractSyntaxFilename :: FilePath
     -- ^ e.g. "Lam4.pgf"
     , concreteSyntaxName     :: String

--- a/lam4-cli/app/Main.hs
+++ b/lam4-cli/app/Main.hs
@@ -60,6 +60,7 @@ simalaOutputConfig = MkSimalaOutputConfig {
 nlgConfig :: NLGConfig
 nlgConfig = MkNLGConfig {
     outputDir = "generated" </> "nlg_en"
+  , resultFilename = "output.txt"
   , abstractSyntaxFilename = "Lam4.pgf"
   , concreteSyntaxName = "Lam4Eng"
 }
@@ -116,7 +117,8 @@ main = do
       nlgEnv <- Render.makeNLGEnv nlgConfig
       let nlRendering = Render.renderCstProgramToNL nlgEnv cstProgram 
       createDirectoryIfMissing True nlgConfig.outputDir
-      -- TODO: Save a json version with the nlg output as a member      
+      writeFileUtf8 (nlgConfig.outputDir </> nlgConfig.resultFilename) nlRendering
+      -- TODO: Save a json version with the nlg output as a member
 
       -- Perform evaluation (if needed)
       _ <- ToSimala.doEvalDeclsTracing options.tracing ToSimala.emptyEnv simalaProgram


### PR DESCRIPTION
I got the impression that this was needed for @Meowyam to get the NL output to display in the other window. 