### PR TITLE
Refactor interfaces and add more docs

### DIFF
--- a/experiments/ide-interfaces/l4extensionprototype/package.json
+++ b/experiments/ide-interfaces/l4extensionprototype/package.json
@@ -66,8 +66,10 @@
   },
   "dependencies": {
     "ts-pattern": "^5.5.0",
+    "vscode-jsonrpc": "^8.2.1",
     "vscode-languageclient": "^9.0.1",
     "vscode-languageserver": "^9.0.1",
+    "vscode-languageserver-protocol": "^3.17.5",
     "zod-to-json-schema": "^3.23.5"
   }
 }

--- a/experiments/ide-interfaces/l4extensionprototype/pnpm-lock.yaml
+++ b/experiments/ide-interfaces/l4extensionprototype/pnpm-lock.yaml
@@ -8,12 +8,18 @@ dependencies:
   ts-pattern:
     specifier: ^5.5.0
     version: 5.5.0
+  vscode-jsonrpc:
+    specifier: ^8.2.1
+    version: 8.2.1
   vscode-languageclient:
     specifier: ^9.0.1
     version: 9.0.1
   vscode-languageserver:
     specifier: ^9.0.1
     version: 9.0.1
+  vscode-languageserver-protocol:
+    specifier: ^3.17.5
+    version: 3.17.5
   zod-to-json-schema:
     specifier: ^3.23.5
     version: 3.23.5(zod@3.23.8)
@@ -2218,6 +2224,11 @@ packages:
 
   /vscode-jsonrpc@8.2.0:
     resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
+    dev: false
+
+  /vscode-jsonrpc@8.2.1:
+    resolution: {integrity: sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==}
     engines: {node: '>=14.0.0'}
     dev: false
 

--- a/experiments/ide-interfaces/l4extensionprototype/src/interfaces/README.md
+++ b/experiments/ide-interfaces/l4extensionprototype/src/interfaces/README.md
@@ -1,0 +1,20 @@
+# README
+
+## Useful resources
+
+[https://github.com/dotnet/vscode-csharp/tree/main/src/razor/src/rpc](https://github.com/dotnet/vscode-csharp/tree/main/src/razor/src/rpc)
+though they do have a lot of functionality that we probably don't need
+
+The things we might need to add in the medium term might be things like the following (or similar things in the visualization sphere):
+
+* https://github.com/dotnet/vscode-csharp/blob/main/src/razor/src/rpc/serializableRange.ts
+* https://github.com/dotnet/vscode-csharp/blob/main/src/razor/src/rpc/razorMapToDocumentRangesRequest.ts
+* https://github.com/dotnet/vscode-csharp/blob/main/src/razor/src/rpc/razorMapToDocumentRangesResponse.ts
+
+* https://github.com/dotnet/vscode-csharp/blob/main/src/razor/src/rpc/serializableTextEdit.ts
+* https://github.com/dotnet/vscode-csharp/blob/main/src/razor/src/rpc/serverTextSpan.ts
+* https://github.com/dotnet/vscode-csharp/blob/main/src/razor/src/rpc/serverTextChange.ts
+
+* [Semantic tokens](https://github.com/dotnet/vscode-csharp/tree/5b414fa5413c85641bb07c4bb4116347dda9a4a9/src/razor/src/semantic) --- though Hannes probably already has this sorted out.
+
+Most of these seem like they'd be straightforward to add later, so I'll probably just wait till it's clear they are needed before adding them.

--- a/experiments/ide-interfaces/l4extensionprototype/src/interfaces/decisionLogicIRNode.ts
+++ b/experiments/ide-interfaces/l4extensionprototype/src/interfaces/decisionLogicIRNode.ts
@@ -4,6 +4,13 @@ import { JsonRPCRequest, JsonRPCMessage, Result } from "./utilTypes";
   Protocol interfaces
 ***********************/
 
+/* 
+My focus was on the non-Json-RPC-specific / 'business-logic-specific' parts,
+so there might be subtle JsonRPC things that I didn't get right.
+But I'm hoping that won't be an issue / that this is still clear enough,
+since we'll presumably be using libraries to handle that sort of plumbing.
+*/
+
 /** Might need fields like `code` to respect JsonRPC spec. Please mentally fill those in if so. */
 export interface VisualizeIRError {
   message: string;
@@ -19,6 +26,7 @@ But this is not a component that the VSCode extension would know about.
 export interface VisualizeDecisionLogicIRRequest extends JsonRPCRequest {
   readonly method: "visualizeDecisionLogicIR";
   readonly params: VisualizeDecisionLogicIRInfo;
+  /** The `Result` type might need to be tweaked to conform with JsonRPC spec --- the idea here is just that we want something like a Either type. */
   readonly result: Result<VisualizeIRError, VisualizeDecisionLogicIRResult>;
 }
 
@@ -29,6 +37,44 @@ export interface VisualizeDecisionLogicIRInfo {
 export interface VisualizeDecisionLogicIRResult extends JsonRPCMessage {
   readonly html: string;
 }
+
+/**********************
+         IR 
+************************
+
+-----------------
+  Design intent
+-----------------
+
+I framed the visualizer inputs in terms of PL concepts, 
+as opposed to 'lower-level' graph visualization concepts (e.g. overlaying and connecting nodes),
+because my understanding was that Matthew Waddington wanted 
+the produced components to be things that other legal DSLs can also benefit from.
+In particular, he seemed to want something like 
+a 'L4-lite' intermediate representation whose semantics was mostly confined to propositional logic,
+and that other legal DSLs can either compile to (so as, e.g., to use tools whose inputs
+are in terms of this intermediate representation)
+or extend with their own features.
+
+Furthermore, if the visualizer inputs were framed in terms of, e.g., 'lower-level' graph visualization concepts,
+that wouldn't be very different from visualization tools that already exist for visualizing graphs.
+
+The other design goal was to try to come up with something that's simple while still being relatively extensible.
+If there are things that do not seem easily extensible, please do not hesitate to point those out.
+
+---------------------------------------
+  Relationship to previous prototypes
+---------------------------------------
+In coming up with the following, I 
+* looked through all the visualization-related components we've previously done (mathlangvis, Jules' ladder diagram, Meng's layman, vue pure pdpa) 
+and did a quick personal assessment of their software interfaces, design intents, 
+and practical pros and cons when it came to re-using them for this usecase.
+ (In particular, I've run and played with most of them.)
+* also looked at Maryam's https://github.com/Meowyam/lspegs
+
+If it seems like there are aspects of extant work that have not been considered in the following,
+it's likely because they are either not needed for the v1 mvp or looked like they'd have other practical disadvantages.
+*/
 
 /*****************
   Core IR node

--- a/experiments/ide-interfaces/l4extensionprototype/src/interfaces/decisionLogicIRNode.ts
+++ b/experiments/ide-interfaces/l4extensionprototype/src/interfaces/decisionLogicIRNode.ts
@@ -39,11 +39,26 @@ export interface IRNode {
   readonly $type: string;
   /** (Stable) ID for this IRNode */
   readonly id: IRId;
+  readonly annotation: IRNodeAnnotation;
 }
 
 /** Stable IDs useful for things like bidirectional synchronization down the road */
 interface IRId {
   readonly id: number;
+}
+
+/** A separate record type for annotations makes it easy to add more annotation types in the future */
+export interface IRNodeAnnotation {
+  /** The label is what gets displayed in or around the box. */
+  readonly label?: string;
+}
+
+/**
+I can't think of a scenario where we'd plausibly want atomic propositions in something like a ladder diagram to not have a label;
+and conversely it is easy to think of scenarios where one forgets to add the label for atomic propositions.
+*/
+export interface AtomicPropositionAnnotation extends IRNodeAnnotation {
+  readonly label: string;
 }
 
 /*******************************
@@ -61,7 +76,6 @@ export interface BinExpr extends IRNode {
   readonly op: BinOp;
   readonly left: IRExpr;
   readonly right: IRExpr;
-  readonly label?: string;
 }
 
 export interface Not extends IRNode {
@@ -72,6 +86,5 @@ export interface Not extends IRNode {
 export interface AtomicProposition extends IRNode {
   readonly $type: "AtomicProposition";
   readonly value: "False" | "True" | "Unknown";
-  /** The label is what gets displayed in or around the box */
-  readonly label: string;
+  readonly annotation: AtomicPropositionAnnotation;
 }

--- a/experiments/ide-interfaces/l4extensionprototype/src/interfaces/visualizeProgramRequest.ts
+++ b/experiments/ide-interfaces/l4extensionprototype/src/interfaces/visualizeProgramRequest.ts
@@ -1,5 +1,5 @@
 import { URI } from "vscode-uri";
-import { RequestType } from "vscode-languageclient/node";
+import { RequestType } from "vscode-languageserver-protocol";
 import { z } from "zod";
 
 /*****************
@@ -20,6 +20,8 @@ export const uriSchema = z
  * Request type for visualizing L4 programs.
  * Can think in the future about whether to have different requests for visualizations of different L4 constructs.
  *
+ * We don't need to add JsonRPC or some kind of Maybe type because `RequestType` already takes care of that.
+ * 
  * @type {RequestType<VisualizeProgramInfo, VisualizeProgramResponse, void>}
  *
  * @remarks
@@ -31,11 +33,9 @@ export const uriSchema = z
  * Method Name: `"l4/visualizeProgram"`
  */
 export namespace VisualizeProgramRequest {
-  export const type: RequestType<
-    VisualizeProgramInfo,
-    VisualizeProgramResponse,
-    void
-  > = new RequestType("l4/visualizeProgram");
+  export const type: RequestType<VisualizeProgramInfo, VisualizeProgramResponse, void> = new RequestType(
+    "l4/visualizeProgram",
+  );
 }
 
 /* aka:


### PR DESCRIPTION
1. Refactor: Standardize the annotation mechanism for IRNode and make it more extensible / less restrictive.
2. Add more docs, esp. re design intent.
3. Add link to useful-looking resource for LSP interfaces