### PR TITLE
Explicitly set `allow-newer` for gf

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -15,8 +15,10 @@ source-repository-package
   location: https://github.com/inariksit/gf-core
   tag: 3a1782a5c8221101c330b6ee50ff5dd6fffb7410
 
-allow-newer: *
-allow-older: *
+allow-newer:
+    gf:base,
+    gf:ghc-prim,
+    gf:mtl,
 
 package *
     ghc-options: -haddock -fwrite-ide-info

--- a/lam4-backend/lam4-backend.cabal
+++ b/lam4-backend/lam4-backend.cabal
@@ -84,8 +84,8 @@ library
         simala,
         relude,
         gf,
-        cgi == 3001.5.0.0,
-        multipart == 0.2.0,
+        cgi ^>= 3001.5.0.1,
+        multipart ^>= 0.2.1,
         lens-regex-pcre,
         string-interpolate
 


### PR DESCRIPTION
Avoid 'allow-newer: *' and 'allow-older: *' as this is easily affected by the index-state of the respective user, causing build failures that aren't trivial to resolve.